### PR TITLE
Fix: repository->execute called only once

### DIFF
--- a/Tests/Functional/ORM/RepositoryTest.php
+++ b/Tests/Functional/ORM/RepositoryTest.php
@@ -233,6 +233,7 @@ class RepositoryTest extends ElasticsearchTestCase
         $search->addFilter(new PrefixFilter('title', 'dummy'));
         $searchResult = $repo->execute($search, Repository::RESULTS_OBJECT);
 
+        $searchResult=$repo->execute($search, Repository::RESULTS_OBJECT);
         $this->assertInstanceOf(
             '\ONGR\ElasticsearchBundle\Result\DocumentIterator',
             $searchResult


### PR DESCRIPTION
fixes https://github.com/ongr-io/ElasticsearchBundle/issues/5
