### PR TITLE
AbstractResultsIterator::current() returns null if no documents are found

### DIFF
--- a/Result/AbstractResultsIterator.php
+++ b/Result/AbstractResultsIterator.php
@@ -93,6 +93,10 @@ abstract class AbstractResultsIterator implements \Countable, \Iterator, \ArrayA
     public function offsetGet($offset)
     {
         if (!isset($this->converted[$offset])) {
+            if (!isset($this->documents[$offset])) {
+                return null;
+            }
+
             $this->converted[$offset] = $this->convertDocument($this->documents[$offset]);
 
             // Clear memory.

--- a/Tests/Functional/Result/DocumentIteratorTest.php
+++ b/Tests/Functional/Result/DocumentIteratorTest.php
@@ -84,4 +84,18 @@ class DocumentIteratorTest extends ElasticsearchTestCase
             }
         }
     }
+
+    /**
+     * Tests if current() returns null when data doesn't exist.
+     */
+    public function testCurrentWithEmptyIterator()
+    {
+        $repo = $this->getManager()->getRepository('ONGRTestingBundle:Content');
+        $search = $repo
+            ->createSearch()
+            ->addQuery(new MatchAllQuery());
+        $result = $repo->execute($search);
+
+        $this->assertNull($result->current());
+    }
 }


### PR DESCRIPTION
Closes #51
