### PR TITLE
Removed underscore properties in annotations.

### DIFF
--- a/Annotation/MultiField.php
+++ b/Annotation/MultiField.php
@@ -16,42 +16,43 @@ namespace ONGR\ElasticsearchBundle\Annotation;
  *
  * @Annotation
  * @Target("ANNOTATION")
+ * @Attributes({
+ *     @Attribute("index_analyzer", type = "string"),
+ *     @Attribute("search_analyzer",  type = "string"),
+ *     @Attribute("name", type = "string", required = true),
+ *     @Attribute("type", type = "string", required = true),
+ *     @Attribute("index", type = "string"),
+ *     @Attribute("analyzer", type = "string"),
+ * })
  */
 final class MultiField
 {
     /**
-     * @var string
+     * @var array
+     */
+    private $settings;
+
+    /**
+     * Constructor for lowercase settings.
      *
-     * @Required
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        $this->type = $values['type'];
+        $this->name = $values['name'];
+        $this->settings = $values;
+    }
+
+    /**
+     * @var string
      */
     public $name;
 
     /**
      * @var string
-     *
-     * @Required
      */
     public $type;
-
-    /**
-     * @var string
-     */
-    public $index;
-
-    /**
-     * @var string
-     */
-    public $analyzer;
-
-    /**
-     * @var string
-     */
-    public $index_analyzer;
-
-    /**
-     * @var string
-     */
-    public $search_analyzer;
 
     /**
      * Filters object values.
@@ -61,7 +62,7 @@ final class MultiField
     public function filter()
     {
         return array_diff_key(
-            array_filter(get_object_vars($this)),
+            array_filter($this->settings),
             array_flip(['name'])
         );
     }

--- a/Annotation/Property.php
+++ b/Annotation/Property.php
@@ -16,73 +16,58 @@ namespace ONGR\ElasticsearchBundle\Annotation;
  *
  * @Annotation
  * @Target("PROPERTY")
+ * @Attributes({
+ *     @Attribute("index_analyzer", type = "string"),
+ *     @Attribute("search_analyzer",  type = "string"),
+ *     @Attribute("name", type = "string", required = true),
+ *     @Attribute("type", type = "string", required = true),
+ *     @Attribute("index", type = "string"),
+ *     @Attribute("analyzer", type = "string"),
+ *     @Attribute("boost", type = "float"),
+ *     @Attribute("payloads", type = "bool"),
+ *     @Attribute("fields", type = "array<\ONGR\ElasticsearchBundle\Annotation\MultiField>"),
+ *     @Attribute("fielddata", type = "array"),
+ *     @Attribute("objectName", type = "string"),
+ *     @Attribute("multiple", type = "bool"),
+ * })
  */
 final class Property
 {
     /**
-     * @var string
+     * @var array
+     */
+    private $settings;
+
+    /**
+     * Constructor for lowercase settings.
      *
-     * @Required
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        $this->type = $values['type'];
+        $this->name = $values['name'];
+        $this->objectName = isset($values['objectName']) ? $values['objectName'] : null;
+        $this->multiple = isset($values['multiple']) ? $values['multiple'] : null;
+        $this->settings = $values;
+    }
+
+    /**
+     * @var string
      */
     public $name;
 
     /**
      * @var string
-     *
-     * @Required
      */
     public $type;
 
     /**
      * @var string
      */
-    public $index;
-
-    /**
-     * @var string
-     */
-    public $analyzer;
-
-    /**
-     * @var string
-     */
-    public $index_analyzer;
-
-    /**
-     * @var string
-     */
-    public $search_analyzer;
-
-    /**
-     * @var float
-     */
-    public $boost;
-
-    /**
-     * @var bool
-     */
-    public $payloads;
-
-    /**
-     * @var array<\ONGR\ElasticsearchBundle\Annotation\MultiField>
-     */
-    public $fields;
-
-    /**
-     * @var array
-     */
-    public $fielddata;
-
-    /**
-     * Object name to map.
-     *
-     * @var string
-     */
     public $objectName;
 
     /**
-     * OneToOne or OneToMany.
-     *
      * @var bool
      */
     public $multiple;
@@ -95,7 +80,7 @@ final class Property
     public function filter()
     {
         return array_diff_key(
-            array_filter(get_object_vars($this)),
+            array_filter($this->settings),
             array_flip(['name', 'objectName', 'multiple'])
         );
     }

--- a/Annotation/Suggester/AbstractSuggesterProperty.php
+++ b/Annotation/Suggester/AbstractSuggesterProperty.php
@@ -13,9 +13,38 @@ namespace ONGR\ElasticsearchBundle\Annotation\Suggester;
 
 /**
  * Abstract class for various suggester annotations.
+ *
+ * @Attributes({
+ *     @Attribute("name", type = "string", required = true),
+ *     @Attribute("type", type = "string", required = true),
+ *     @Attribute("index_analyzer", type = "string"),
+ *     @Attribute("search_analyzer",  type = "string"),
+ *     @Attribute("preserve_separators",  type = "int"),
+ *     @Attribute("preserve_position_increments",  type = "bool"),
+ *     @Attribute("max_input_length",  type = "int"),
+ *     @Attribute("objectName", type = "string", required = true),
+ * })
  */
 abstract class AbstractSuggesterProperty
 {
+    /**
+     * @var array
+     */
+    private $settings;
+
+    /**
+     * Constructor for lowercase settings.
+     *
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        $this->settings = $values;
+        $this->name = $values['name'];
+        $this->objectName = $values['objectName'];
+        $this->settings['type'] = $this->type;
+    }
+
     /**
      * @var string
      */
@@ -23,47 +52,13 @@ abstract class AbstractSuggesterProperty
 
     /**
      * @var string
-     *
-     * @Required
      */
     public $name;
 
     /**
      * @var string
-     *
-     * @Required
      */
-     public $objectName;
-
-    /**
-     * @var string
-     */
-    public $index_analyzer;
-
-    /**
-     * @var string
-     */
-    public $search_analyzer;
-
-    /**
-     * @var int
-     */
-    public $preserve_separators;
-
-    /**
-     * @var bool
-     */
-    public $preserve_position_increments;
-
-    /**
-     * @var int
-     */
-    public $max_input_length;
-
-    /**
-     * @var bool
-     */
-    public $payloads;
+    public $objectName;
 
     /**
      * Returns required properties.
@@ -75,7 +70,7 @@ abstract class AbstractSuggesterProperty
     public function filter($extraExclude = [])
     {
         return array_diff_key(
-            array_filter(get_object_vars($this)),
+            array_filter($this->settings),
             array_flip(array_merge(['name', 'objectName', 'classObjectName'], $extraExclude))
         );
     }

--- a/Annotation/Suggester/ContextSuggesterProperty.php
+++ b/Annotation/Suggester/ContextSuggesterProperty.php
@@ -9,11 +9,29 @@ use ONGR\ElasticsearchBundle\Annotation\Suggester\Context\AbstractContext;
  *
  * @Annotation
  * @Target("PROPERTY")
+ * @Attributes({
+ *     @Attribute(
+ *        "context",
+ *        type = "array<\ONGR\ElasticsearchBundle\Annotation\Suggester\Context\AbstractContext>",
+ *        required = true
+ *     ),
+ * })
  */
 class ContextSuggesterProperty extends AbstractSuggesterProperty
 {
     /**
-     * @var array<\ONGR\ElasticsearchBundle\Annotation\Suggester\Context\AbstractContext>
+     * Constructor for lowercase settings.
+     *
+     * @param array $values
+     */
+    public function __construct(array $values)
+    {
+        $this->context = $values['context'];
+        parent::__construct($values);
+    }
+
+    /**
+     * @var AbstractContext[]
      */
     public $context;
 

--- a/Mapping/MetadataCollector.php
+++ b/Mapping/MetadataCollector.php
@@ -15,8 +15,10 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Doctrine\Common\Annotations\FileCacheReader;
 use Doctrine\Common\Util\Inflector;
 use ONGR\ElasticsearchBundle\Annotation\Document;
+use ONGR\ElasticsearchBundle\Annotation\Inherit;
 use ONGR\ElasticsearchBundle\Annotation\MultiField;
 use ONGR\ElasticsearchBundle\Annotation\Property;
+use ONGR\ElasticsearchBundle\Annotation\Skip;
 use ONGR\ElasticsearchBundle\Annotation\Suggester\AbstractSuggesterProperty;
 use ONGR\ElasticsearchBundle\Annotation\Suggester\CompletionSuggesterProperty;
 use ONGR\ElasticsearchBundle\Annotation\Suggester\ContextSuggesterProperty;
@@ -477,7 +479,7 @@ class MetadataCollector
      *
      * @param \ReflectionClass $reflectionClass Class to read properties from.
      * @param array            $properties      Properties to skip.
-     * @param array            $flag            If false exludes properties, true only includes properties.
+     * @param bool             $flag            If false exludes properties, true only includes properties.
      *
      * @return array
      */

--- a/Tests/Unit/Annotation/PropertyTest.php
+++ b/Tests/Unit/Annotation/PropertyTest.php
@@ -20,12 +20,7 @@ class PropertyTest extends \PHPUnit_Framework_TestCase
      */
     public function testFilter()
     {
-        $type = new Property();
-
-        $type->name = 'id';
-        $type->index = 'no_index';
-        $type->type = 'string';
-        $type->analyzer = null;
+        $type = new Property(['name' => 'id', 'index' => 'no_index', 'type' => 'string', 'analyzer' => null]);
 
         $this->assertEquals(
             [


### PR DESCRIPTION
Closes #75.
> Note that I don't like this myself, but I wasn't able to figure out a better way to do this. In my opinion, annotation setting names and elasticsearch setting names should match, so it's easier to understand for end user. Instead of converting this from underscore to camelCase and back to underscore again, I removed the properties and store them in array. Please note that we would have to use annotation to define properties and constructor either way.