### PR TITLE
Expose elasticsearch hosts from config_test.yml to parameters_test.yml + [BUGFIX] Fixed json substr triming from url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /Tests/app/data/
 /phpunit.xml
 /composer.lock
+/Tests/app/config/parameters_test.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - wget -q -O conf.py https://raw.githubusercontent.com/ongr-io/docs-aggregator/master/source/conf-travis.py
 
 before_script:
-  - composer install
+  - composer install --no-interaction
 
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/DataCollector/ElasticsearchDataCollector.php
+++ b/DataCollector/ElasticsearchDataCollector.php
@@ -158,7 +158,7 @@ class ElasticsearchDataCollector implements DataCollectorInterface
                 $this->time += $record['context']['duration'];
                 $this->addQuery($route, $record, $queryBody);
             } else {
-                $position = strpos($record['message'], '-d');
+                $position = strpos($record['message'], ' -d');
                 $queryBody = $position !== false ? substr($record['message'], $position + 3) : '';
             }
         }
@@ -174,7 +174,7 @@ class ElasticsearchDataCollector implements DataCollectorInterface
     private function addQuery($route, $record, $queryBody)
     {
         parse_str(parse_url($record['context']['uri'], PHP_URL_QUERY), $httpParameters);
-        $body = json_decode(trim($queryBody, "'"), true);
+        $body = json_decode(trim($queryBody, " '\r\t\n"), true);
         $this->queries[$route][] = array_merge(
             [
                 'body' => $body !== null ? json_encode($body, JSON_PRETTY_PRINT) : '',

--- a/Tests/Functional/DataCollector/ElasticsearchDataCollectorTest.php
+++ b/Tests/Functional/DataCollector/ElasticsearchDataCollectorTest.php
@@ -88,16 +88,12 @@ class ElasticsearchDataCollectorTest extends ElasticsearchTestCase
         $queries = $this->getCollector()->getQueries();
 
         $lastQuery = end($queries[ElasticsearchDataCollector::UNDEFINED_ROUTE]);
-        $time = $lastQuery['time'];
-        unset($lastQuery['time']);
+        $this->checkQueryParameters($lastQuery);
 
-        $this->assertGreaterThan(0.0, $time, 'Time should be greater than 0');
         $this->assertEquals(
             [
                 'body' => '',
                 'method' => 'GET',
-                'path' => '/ongr-elasticsearch-bundle-test/product/2',
-                'host' => '127.0.0.1',
                 'httpParameters' => [],
                 'scheme' => 'http',
                 'port' => 9200,
@@ -122,16 +118,12 @@ class ElasticsearchDataCollectorTest extends ElasticsearchTestCase
 
         $queries = $this->getCollector()->getQueries();
         $lastQuery = end($queries[ElasticsearchDataCollector::UNDEFINED_ROUTE]);
-        $time = $lastQuery['time'];
-        unset($lastQuery['time']);
+        $this->checkQueryParameters($lastQuery);
 
-        $this->assertGreaterThan(0.0, $time, 'Time should be greater than 0');
         $this->assertEquals(
             [
                 'body' => $this->getFileContents('collector_body_0.json'),
                 'method' => 'POST',
-                'path' => '/ongr-elasticsearch-bundle-test/product/_search',
-                'host' => '127.0.0.1',
                 'httpParameters' => [],
                 'scheme' => 'http',
                 'port' => 9200,
@@ -139,6 +131,26 @@ class ElasticsearchDataCollectorTest extends ElasticsearchTestCase
             $lastQuery,
             'Logged data did not match expected data.'
         );
+    }
+
+    /**
+     * Checks query parameters that are not static.
+     *
+     * @param array $query
+     */
+    public function checkQueryParameters(&$query)
+    {
+        $this->assertArrayHasKey('time', $query, 'Query should have time set.');
+        $this->assertGreaterThan(0.0, $query['time'], 'Time should be greater than 0');
+        unset($query['time']);
+
+        $this->assertArrayHasKey('host', $query, 'Query should have host set.');
+        $this->assertNotEmpty($query['host'], 'Host should not be empty');
+        unset($query['host']);
+
+        $this->assertArrayHasKey('path', $query, 'Query should have host path set.');
+        $this->assertNotEmpty($query['path'], 'Path should not be empty.');
+        unset($query['path']);
     }
 
     /**

--- a/Tests/Functional/DependencyInjection/ElasticsearchExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/ElasticsearchExtensionTest.php
@@ -11,10 +11,13 @@
 
 namespace ONGR\ElasticsearchBundle\Tests\Functional\DependencyInjection;
 
+use ONGR\ElasticsearchBundle\Test\TestHelperTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 class ElasticsearchExtensionTest extends WebTestCase
 {
+    use TestHelperTrait;
+
     /**
      * @return array
      */
@@ -81,16 +84,12 @@ class ElasticsearchExtensionTest extends WebTestCase
 
         $expectedConnections = [
             'default' => [
-                'hosts' => ['127.0.0.1:9200'],
-                'index_name' => 'ongr-elasticsearch-bundle-test',
                 'settings' => [
                     'refresh_interval' => -1,
                     'number_of_replicas' => 0,
                 ],
             ],
             'bar' => [
-                'hosts' => ['127.0.0.1:9200'],
-                'index_name' => 'ongr-elasticsearch-bundle-bar-test',
                 'settings' => [
                     'refresh_interval' => -1,
                     'number_of_replicas' => 1,
@@ -113,7 +112,7 @@ class ElasticsearchExtensionTest extends WebTestCase
         ];
         $actualManagers = $container->getParameter('es.managers');
 
-        $this->assertEquals($expectedConnections, $actualConnections);
+        $this->assertArrayContainsArray($expectedConnections, $actualConnections);
         $this->assertEquals($expectedManagers, $actualManagers);
     }
 }

--- a/Tests/app/config/config_test.yml
+++ b/Tests/app/config/config_test.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: parameters_test.yml }
+
 # Framework Configuration
 framework:
     secret: "TOP-SECRET"
@@ -7,15 +10,15 @@ ongr_elasticsearch:
     connections:
         default:
             hosts:
-                - { host: 127.0.0.1:9200 }
-            index_name: ongr-elasticsearch-bundle-test
+                - { host: "%elasticsearch_test_connection.host%" }
+            index_name: "%elasticsearch_test_connection.default.index_name%"
             settings:
                 refresh_interval: -1
                 number_of_replicas: 0
         bar:
             hosts:
-                - { host: 127.0.0.1:9200 }
-            index_name: ongr-elasticsearch-bundle-bar-test
+                - { host: "%elasticsearch_test_connection.host%" }
+            index_name: "%elasticsearch_test_connection.bar.index_name%"
             settings:
                 refresh_interval: -1
                 number_of_replicas: 1

--- a/Tests/app/config/parameters_test.yml.dist
+++ b/Tests/app/config/parameters_test.yml.dist
@@ -1,0 +1,4 @@
+parameters:
+    elasticsearch_test_connection.host: "127.0.0.1:9200"
+    elasticsearch_test_connection.default.index_name: "ongr-elasticsearch-bundle-default-test"
+    elasticsearch_test_connection.bar.index_name: "ongr-elasticsearch-bundle-bar-test"

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,23 @@
         "mikey179/vfsStream": "~1.4",
         "phpunit/phpunit": "~4.1",
         "squizlabs/php_codesniffer": "~1.5",
-        "ongr/ongr-strict-standard": "~1.0"
+        "ongr/ongr-strict-standard": "~1.0",
+        "incenteev/composer-parameter-handler": "~2.0"
     },
     "autoload": {
         "psr-4": { "ONGR\\ElasticsearchBundle\\": "" }
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
+        ],
+        "post-update-cmd": [
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
+        ]
+    },
+    "extra": {
+        "incenteev-parameters": {
+            "file": "Tests/app/config/parameters_test.yml"
+        }
     }
 }


### PR DESCRIPTION
Closes #168

Also added `incenteev/composer-parameter-handler` in `require-dev` so that we could set testing parameters for better UX.