### PR TITLE
Increased Scrutinizer external-code-coverage timeout.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,7 +2,7 @@ imports:
   - php
 tools:
   external_code_coverage:
-      timeout: 600
+      timeout: 900
 filter:
   excluded_paths:
     - Tests/*


### PR DESCRIPTION
External code coverage timeout increased to 15 minutes.