### PR TITLE
Code coverage should only be executed once.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ install:
   - wget -q -O conf.py https://raw.githubusercontent.com/ongr-io/docs-aggregator/master/source/conf-travis.py
 
 before_script:
+  - if [[ $TRAVIS_PHP_VERSION = 5.6 && $ELASTICSEARCH = 1.4.4 ]]; then COVERAGE_NEEDED=true; else COVERAGE_NEEDED=false; fi
+  - if [[ $COVERAGE_NEEDED = false ]]; then phpenv config-rm xdebug.ini || true; fi
   - composer install --no-interaction
 
 script:
@@ -36,9 +38,12 @@ script:
   - sphinx-build -nWq -b html -c . Resources/doc _build/html
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && wget --post-data="" -q -O /dev/null http://readthedocs.org/build/ongr'
+  - >
+    if [[ $COVERAGE_NEEDED = true ]]; then
+        wget https://scrutinizer-ci.com/ocular.phar;
+        php ocular.phar code-coverage:upload --format=php-clover coverage.clover;
+    fi
 
 notifications:
   slack: ongr:oyJ6inOcsttTBsnkuHV6dWbT


### PR DESCRIPTION
Turns out we will need to run PHPUnit with xDebug at least once to get code coverage. For example, to get code coverage from Scrutinizer you must use its CI which will also run PHPUnit multiple times, CoverAlls require you to send data to it from CI like we're sending it now to Scrutinizer, wasn't able to find a tool which works differently.

So I took an idea from Doctrine https://github.com/doctrine/doctrine2/commit/934e4fdde4e07d464a0041117732e908dde3cbde, but instead of enabling code coverage on a specific version, I disabled xDebug (which also disables code coverage) on all except one version (which is specified by ES version and PHP version).