### PR TITLE
elastic/elasticsearch-php 2.x adoption

### DIFF
--- a/Tests/Functional/DataCollector/ElasticsearchDataCollectorTest.php
+++ b/Tests/Functional/DataCollector/ElasticsearchDataCollectorTest.php
@@ -121,7 +121,7 @@ class ElasticsearchDataCollectorTest extends ElasticsearchTestCase
         $this->assertEquals(
             [
                 'body' => $this->getFileContents('collector_body_0.json'),
-                'method' => 'POST',
+                'method' => 'GET',
                 'httpParameters' => [],
                 'scheme' => 'http',
                 'port' => 9200,

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": ">=5.4",
         "symfony/symfony": "~2.3",
-        "elasticsearch/elasticsearch": "~1.0",
+        "elasticsearch/elasticsearch": "~2.0@beta",
+        "monolog/monolog": "~1.0",
         "doctrine/annotations": "~1.2"
     },
     "require-dev": {


### PR DESCRIPTION
in order to test, need to add these lines in ClientBuilder.php
use Monolog\Logger;
use Monolog\Handler\StreamHandler;
use Monolog\Processor\IntrospectionProcessor;