### PR TITLE
Repository service uses factory method

### DIFF
--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -63,9 +63,12 @@ class MappingPass implements CompilerPassInterface
             foreach ($bundlesMetadata as $repository => $data) {
                 $repositoryDefinition = new Definition(
                     'ONGR\ElasticsearchBundle\ORM\Repository',
+                    [$repository]
+                );
+                $repositoryDefinition->setFactory(
                     [
-                        $managerDefinition,
-                        [$repository],
+                        new Reference(sprintf('es.manager.%s', $managerName)),
+                        'getRepository',
                     ]
                 );
 

--- a/Tests/Functional/DependencyInjection/Compiler/MappingPassTest.php
+++ b/Tests/Functional/DependencyInjection/Compiler/MappingPassTest.php
@@ -13,6 +13,8 @@ namespace ONGR\ElasticsearchBundle\Tests\Functional\DependencyInjection\Compiler
 
 use ONGR\ElasticsearchBundle\Client\Connection;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
+use ONGR\ElasticsearchBundle\ORM\Manager;
+use ONGR\ElasticsearchBundle\ORM\Repository;
 use ONGR\ElasticsearchBundle\Test\AbstractElasticsearchTestCase;
 
 /**
@@ -46,5 +48,24 @@ class MappingPassTest extends AbstractElasticsearchTestCase
         );
 
         $this->assertEquals($expectedMapping['product']['properties'], $productMapping['properties']);
+    }
+
+    /**
+     * Check if changed index name in manager is passed into repository services.
+     */
+    public function testConnectionIndexNameChange()
+    {
+        $container = $this->createClient()->getContainer();
+
+        /** @var Manager $manager */
+        $manager = $container->get('es.manager.default');
+        $manager->getConnection()->setIndexName('new-index');
+
+        /** @var Repository $repository */
+        $repository = $container->get('es.manager.default.product');
+        $this->assertEquals(
+            'new-index',
+            $repository->getManager()->getConnection()->getIndexName()
+        );
     }
 }


### PR DESCRIPTION
Situation:
```php
$manager = $client->getContainer()->get('es.manager.default');
$manager->getConnection()->getIndexName();
// Returns 'index'
$manager->getConnection()->setIndexName('new-index');
$manager->getConnection()->getIndexName();
// Returns 'new-index'
$repository = $client->getContainer()->get('es.manager.default.category');
$repository->getManager()->getConnection()->getIndexName();
// Returns 'index', tough it should have returned 'new-index'
```
An index name change applied for the manager does not apply to the repository services. This happens because each repository Definition has it's own parameters cached in Container cache. Generating repositories by factory fixes this issue.