### PR TITLE
Endpoint factory messages

### DIFF
--- a/DSL/SearchEndpoint/SearchEndpointFactory.php
+++ b/DSL/SearchEndpoint/SearchEndpointFactory.php
@@ -41,7 +41,7 @@ class SearchEndpointFactory
     public static function get($type)
     {
         if (!array_key_exists($type, self::$endpoints)) {
-            throw new \RuntimeException();
+            throw new \RuntimeException('Endpoint does not exist.');
         }
 
         return new self::$endpoints[$type]();

--- a/DSL/SearchEndpoint/SearchEndpointFactory.php
+++ b/DSL/SearchEndpoint/SearchEndpointFactory.php
@@ -37,19 +37,13 @@ class SearchEndpointFactory
      * @return SearchEndpointInterface
      *
      * @throws \RuntimeException Endpoint does not exist.
-     * @throws \DomainException  Endpoint is not implementing SearchEndpointInterface.
      */
     public static function get($type)
     {
         if (!array_key_exists($type, self::$endpoints)) {
             throw new \RuntimeException();
         }
-        $endpoint = new self::$endpoints[$type]();
 
-        if ($endpoint instanceof SearchEndpointInterface) {
-            return $endpoint;
-        }
-
-        throw new \DomainException();
+        return new self::$endpoints[$type]();
     }
 }

--- a/Tests/Unit/DSL/SearchEndpoint/SearchEndpointFactoryTest.php
+++ b/Tests/Unit/DSL/SearchEndpoint/SearchEndpointFactoryTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\Unit\SearchEndpoint;
+
+use ONGR\ElasticsearchBundle\DSL\SearchEndpoint\SearchEndpointFactory;
+
+/**
+ * Unit test class for search endpoint factory.
+ */
+class SearchEndpointFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests get method exception.
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testGet()
+    {
+        SearchEndpointFactory::get('foo');
+    }
+}


### PR DESCRIPTION
Removed because there could not be any new endpoint injected because of private property, so it had no use. It is up to maintainer to make sure.