### PR TITLE
Custom repository class can be defined via Document annotation.

### DIFF
--- a/Annotation/Document.php
+++ b/Annotation/Document.php
@@ -32,6 +32,11 @@ final class Document
     /**
      * @var string
      */
+    public $repositoryClass;
+
+    /**
+     * @var string
+     */
     public $parent;
 
     /**

--- a/Mapping/DocumentParser.php
+++ b/Mapping/DocumentParser.php
@@ -117,6 +117,7 @@ class DocumentParser
                         '_ttl' => $class->ttl,
                         'enabled' => $class->enabled,
                         '_all' => $class->all,
+                        'repositoryClass' => $class->repositoryClass,
                     ],
                     'aliases' => $this->getAliases($reflectionClass),
                     'objects' => $this->getObjects(),

--- a/ORM/Manager.php
+++ b/ORM/Manager.php
@@ -102,6 +102,17 @@ class Manager
      */
     private function createRepository(array $types)
     {
+        if (count($types) === 1) {
+            $type = reset($types);
+            $mapping = $this->getBundlesMapping();
+            $fields = $mapping[$type]->getFields();
+            if (!empty($fields['repositoryClass'])) {
+                $repositoryClass = $fields['repositoryClass'];
+
+                return new $repositoryClass($this, $types);
+            }
+        }
+
         return new Repository($this, $types);
     }
 

--- a/Tests/Functional/Annotation/DocumentTest.php
+++ b/Tests/Functional/Annotation/DocumentTest.php
@@ -29,6 +29,7 @@ class DocumentTest extends AbstractElasticsearchTestCase
             '_ttl' => null,
             'enabled' => null,
             '_all' => ['enabled' => false],
+            'repositoryClass' => null,
         ];
         $this->assertEquals($expectedResult, $result);
     }

--- a/Tests/Unit/ORM/ManagerTest.php
+++ b/Tests/Unit/ORM/ManagerTest.php
@@ -102,6 +102,35 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Check if custom repository is created.
+     */
+    public function testGetCustomRepository()
+    {
+        $classMetadataMock = $this
+            ->getMockBuilder('ONGR\ElasticsearchBundle\Mapping\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $classMetadataMock
+            ->expects($this->any())
+            ->method('getType');
+        $classMetadataMock
+            ->expects($this->any())
+            ->method('getFields')
+            ->willReturn(['repositoryClass' => '\stdClass']);
+
+        $manager = new Manager(
+            null,
+            $this->getClassMetadataCollectionMock(['rep1' => $classMetadataMock]),
+            $this->getMock('Symfony\Components\EventDispatcher\EventDispatcher')
+        );
+
+        $types = ['rep1'];
+        $repository = $manager->getRepository($types);
+
+        $this->assertEquals(new \stdClass($manager, $types), $repository);
+    }
+
+    /**
      * Returns class metadata collection mock.
      *
      * @param array $metadata


### PR DESCRIPTION
Custom repositories works for single typed repository getter only.