### PR TITLE
Disallowing symfony 2.7, because of breaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": "~2.3,<2.7",
         "elasticsearch/elasticsearch": "~1.0",
         "doctrine/annotations": "~1.2"
     },


### PR DESCRIPTION
Related #391 