### PR TITLE
Changed SF minimum requirement to 2.7

### DIFF
--- a/Mapping/Proxy/ProxyLoader.php
+++ b/Mapping/Proxy/ProxyLoader.php
@@ -13,6 +13,7 @@ namespace ONGR\ElasticsearchBundle\Mapping\Proxy;
 
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Loads proxy documents.
@@ -62,7 +63,7 @@ class ProxyLoader
             $cache->write($code, [new FileResource($reflectionClass->getFileName())]);
         }
 
-        return $cache->__toString();
+        return $cache->getPath();
     }
 
     /**

--- a/Service/Json/JsonReader.php
+++ b/Service/Json/JsonReader.php
@@ -15,7 +15,6 @@ use ONGR\ElasticsearchBundle\Document\DocumentInterface;
 use ONGR\ElasticsearchBundle\ORM\Manager;
 use ONGR\ElasticsearchBundle\Result\Converter;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * Reads records one by one.
@@ -161,20 +160,16 @@ class JsonReader implements \Countable, \Iterator
     /**
      * Configures OptionResolver for resolving document metadata fields.
      *
-     * @param OptionsResolverInterface $resolver
+     * @param OptionsResolver $resolver
      */
-    protected function configureResolver(OptionsResolverInterface $resolver)
+    protected function configureResolver(OptionsResolver $resolver)
     {
         $resolver
             ->setRequired(['_id', '_type', '_source'])
             ->setDefaults(['_score' => null])
-            ->setAllowedTypes(
-                [
-                    '_id' => ['integer', 'string'],
-                    '_type' => 'string',
-                    '_source' => 'array',
-                ]
-            );
+            ->addAllowedTypes('_id', ['integer', 'string'])
+            ->addAllowedTypes('_type', 'string')
+            ->addAllowedTypes('_source', 'array');
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,22 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/symfony": "~2.7.0",
-        "elasticsearch/elasticsearch": "~1.0",
-        "doctrine/annotations": "~1.2"
+        "symfony/class-loader": "~2.7",
+        "symfony/dependency-injection": "~2.7",
+        "symfony/http-kernel": "~2.7",
+        "symfony/console": "~2.7",
+        "symfony/serializer": "~2.7",
+        "symfony/expression-language": "~2.7",
+        "symfony/options-resolver": "~2.7",
+        "symfony/property-access": "~2.7",
+        "doctrine/annotations": "~1.2",
+        "doctrine/inflector": "~1.0",
+        "elasticsearch/elasticsearch": "~1.0"
     },
     "require-dev": {
+        "symfony/framework-bundle": "~2.7",
+        "symfony/finder": "~2.7",
+        "symfony/browser-kit": "~2.7",
         "mikey179/vfsStream": "~1.4",
         "phpunit/phpunit": "~4.4",
         "squizlabs/php_codesniffer": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/symfony": "~2.3,<2.7",
+        "symfony/symfony": "~2.7.0",
         "elasticsearch/elasticsearch": "~1.0",
         "doctrine/annotations": "~1.2"
     },


### PR DESCRIPTION
There are already many places where we use functions added only in 2.6 (e.g. Mapping pass factory). I dont think is worth to keep support for 2.3 and lose all the greatness from symfony while 2.7 is new LTS release. 