### PR TITLE
added dynamic templates for document mappings

### DIFF
--- a/Annotation/Document.php
+++ b/Annotation/Document.php
@@ -59,7 +59,7 @@ final class Document implements DumperInterface
     /**
      * @var array
      */
-    public $dynamic_templates;
+    public $dynamicTemplates;
     
     /**
      * @var array
@@ -82,7 +82,7 @@ final class Document implements DumperInterface
                 '_all' => $this->all,
                 'enabled' => $this->enabled,
                 'dynamic' => $this->dynamic,
-                'dynamic_templates' => $this->dynamic_templates,
+                'dynamic_templates' => $this->dynamicTemplates,
                 'transform' => $this->transform,
                 'dynamic_date_formats' => $this->dynamicDateFormats,
             ],

--- a/Annotation/Document.php
+++ b/Annotation/Document.php
@@ -59,6 +59,11 @@ final class Document implements DumperInterface
     /**
      * @var array
      */
+    public $dynamic_templates;
+    
+    /**
+     * @var array
+     */
     public $transform;
 
     /**
@@ -77,6 +82,7 @@ final class Document implements DumperInterface
                 '_all' => $this->all,
                 'enabled' => $this->enabled,
                 'dynamic' => $this->dynamic,
+                'dynamic_templates' => $this->dynamic_templates,
                 'transform' => $this->transform,
                 'dynamic_date_formats' => $this->dynamicDateFormats,
             ],


### PR DESCRIPTION
Use as follows:

```
/**
 * @ES\Document(
 *      type="myType",
 *      dynamicTemplates={{
 *          "myTemplateName": {
 *              "path_match": "myField.*",
 *              "mapping": {
 *                  "type": "string",
 *                  "index": "not_analyzed"
 *              }
 *          }
 *      }}
 * )
 */
class Article extends AbstractDocument
{
...
```