### PR TITLE
Monolog is not a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         "doctrine/annotations": "~1.2",
         "doctrine/inflector": "~1.0",
         "doctrine/cache": "~1.4",
+        "monolog/monolog": "~1.0",
         "elasticsearch/elasticsearch": "~2.0",
         "ongr/elasticsearch-dsl": "~1.0"
     },
     "require-dev": {
-        "monolog/monolog": "~1.0",
         "mikey179/vfsStream": "~1.4",
         "phpunit/phpunit": "~4.4",
         "squizlabs/php_codesniffer": "~2.0",


### PR DESCRIPTION
It is not dev dependency because Monolg classes are used directly: https://github.com/ongr-io/ElasticsearchBundle/blob/81c3e2b1f857844e46892ce36fd223f7548d3807/Profiler/Handler/CollectionHandler.php#L14