### PR TITLE
Pass raw update query to bulk body

### DIFF
--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -345,10 +345,8 @@ class Manager
         switch ($operation) {
             case 'index':
             case 'create':
-                $this->bulkQueries['body'][] = $query;
-                break;
             case 'update':
-                $this->bulkQueries['body'][] = ['doc' => $query];
+                $this->bulkQueries['body'][] = $query;
                 break;
             case 'delete':
                 // Body for delete operation is not needed to apply.

--- a/Tests/Unit/Service/ManagerTest.php
+++ b/Tests/Unit/Service/ManagerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\Unit\DSL\Aggregation;
+
+use ONGR\ElasticsearchBundle\Service\Manager;
+
+class ManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider for testBulk()
+     *
+     * @return array[]
+     *
+     * @todo Add more test cases to cover all logic
+     */
+    public function getTestBulkData()
+    {
+        return [
+            [
+                'expected' => [
+                    'body' => [
+                        [
+                            'update' => ['_index' => 'test', '_type' => 'product'],
+                        ],
+                        [
+                            'doc' => ['title' => 'Sample'],
+                        ],
+                    ],
+                ],
+                'calls' => [
+                    [
+                        'update',
+                        'product',
+                        [
+                            'doc' => [
+                                'title' => 'Sample',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'expected' => [
+                    'body' => [
+                        [
+                            'update' => ['_index' => 'test', '_type' => 'product'],
+                        ],
+                        [
+                            'script' => 'ctx._source.counter += count',
+                            'params' => ['count' => '4'],
+                        ],
+                    ],
+                ],
+                'calls' => [
+                    [
+                        'update',
+                        'product',
+                        [
+                            'script' => 'ctx._source.counter += count',
+                            'params' => ['count' => '4'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test if manager builds correct bulk structure
+     *
+     * @param array  $expected
+     * @param array  $calls
+     *
+     * @dataProvider getTestBulkData()
+     */
+    public function testBulk($expected, $calls)
+    {
+        $indices = $this->getMock('Elasticsearch\Namespaces\IndicesNamespace', [], [], '', false);
+
+        $esClient = $this->getMock('Elasticsearch\Client', [], [], '', false);
+        $esClient->expects($this->once())->method('bulk')->with($expected);
+        $esClient->expects($this->any())->method('indices')->will($this->returnValue($indices));
+
+        $metadataCollector = $this->getMockBuilder('ONGR\ElasticsearchBundle\Mapping\MetadataCollector')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $converter = $this->getMockBuilder('ONGR\ElasticsearchBundle\Result\Converter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $config = ['readonly' => false];
+
+        $manager = new Manager('test', $config, $esClient, ['index' => 'test'], $metadataCollector, $converter);
+
+        foreach ($calls as list($operation, $type, $query)) {
+            $manager->bulk($operation, $type, $query);
+        }
+
+        $manager->commit();
+    }
+}


### PR DESCRIPTION
Update can be performed not only by passing changed document fields, but also by passing dynamic script. Leave it for developer to provide full update query.

Added unit test also helps as background for issue #471