### PR TITLE
Fixed | Bug in documentation

### DIFF
--- a/Resources/doc/upgrade.md
+++ b/Resources/doc/upgrade.md
@@ -7,7 +7,7 @@
 * All stuffs which were marked as `@deprecated` is removed.
 * DSL query builder was exposed to standalone [ElasticsearchDSL](https://github.com/ongr-io/ElasticsearchDSL) library. So this effects a namespace. Run global search and replace (any modern IDE has this feature) through your project files. Change namespace `ONGR\ElasticsearchDSL\` to `ONGR\ElasticsearchDSL\`.
 * `Client` is now the part of the `Manager`. So if you had any extensions of using client directly e.g. type hinting then search and remove it or change to the `Manager`.
-* `Manager` and `Repository` namespace is changed to `Service`, there is no more `ORM`. Again, run search and replace to find old `ONGR\ElasticsearchBundle\Service` to `ONGR\ElasticsearchBundle\Service\` namespace.
+* `Manager` and `Repository` namespace is changed to `Service`, there is no more `ORM`. Again, run search and replace to find old `ONGR\ElasticsearchBundle\ORM\` to `ONGR\ElasticsearchBundle\Service\` namespace.
 * `Results` namespace was completely refactored. The `Suggestion`, `RawResultScanIterator`, `DocumentScanIterator`, `DocumentHighlight`, `IndicesResult` were removed.
 * Events currently are disabled due previous complex integration. They will be introduced back in the v1.1.0.
 * `config.yml` structure lightly was changed. The `analysis` section appeared where you can define analyzers, filters etc and then reuse them in connections. See [configuration chapter](connection.md) for more information.


### PR DESCRIPTION
I made a mistake in the latest version of this document. It should be `ORM`, instead of `Service`