### PR TITLE
index creation with Elasticsearch 2.0

### DIFF
--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -392,6 +392,12 @@ class Manager
             unset($this->indexSettings['body']['mappings']);
         }
 
+        if (isset($this->indexSettings['body']['mappings'])) {
+            foreach ($this->indexSettings['body']['mappings'] as $type => $mapping) {
+                unset($this->indexSettings['body']['mappings'][$type]['properties']['_ttl']);
+            }
+        }
+
         return $this->getClient()->indices()->create($this->indexSettings);
     }
 

--- a/Tests/Functional/Service/ManagerTest.php
+++ b/Tests/Functional/Service/ManagerTest.php
@@ -188,6 +188,7 @@ class ManagerTest extends AbstractElasticsearchTestCase
         $actualProduct = $this->repository->find('testId');
 
         $this->assertEquals($product->getId(), $actualProduct->getId());
+        $this->assertNotNull($actualProduct->getTtl());
         $this->assertLessThan($product->getTtl(), $actualProduct->getTtl());
     }
 

--- a/Tests/app/fixture/Acme/BarBundle/Document/Product.php
+++ b/Tests/app/fixture/Acme/BarBundle/Document/Product.php
@@ -17,7 +17,7 @@ use ONGR\ElasticsearchBundle\Document\AbstractDocument;
 /**
  * Product document for testing.
  *
- * @ES\Document(type="product")
+ * @ES\Document(type="product", ttl={"enabled"=true})
  */
 class Product extends AbstractDocument
 {


### PR DESCRIPTION
Also ManagerTest case fixed. Before this ttl was null and null is less than 1+.
closes #493 