### PR TITLE
Add special annotation for meta fields

### DIFF
--- a/Annotation/MetaField.php
+++ b/Annotation/MetaField.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Annotation;
+
+/**
+ * Annotation used to check mapping type during the parsing process.
+ *
+ * @Annotation
+ * @Target("PROPERTY")
+ */
+final class MetaField
+{
+    /**
+     * Name of the field.
+     *
+     * @var string
+     *
+     * @Required
+     */
+    public $name;
+}

--- a/Document/AbstractDocument.php
+++ b/Document/AbstractDocument.php
@@ -21,28 +21,28 @@ abstract class AbstractDocument implements DocumentInterface
     /**
      * @var string
      *
-     * @ES\Property(type="string", name="_id")
+     * @ES\MetaField(name="_id")
      */
     public $id;
 
     /**
      * @var string
      *
-     * @ES\Property(type="float", name="_score")
+     * @ES\MetaField(name="_score")
      */
     public $score;
 
     /**
      * @var string
      *
-     * @ES\Property(type="string", name="_parent")
+     * @ES\MetaField(name="_parent")
      */
     public $parent;
 
     /**
      * @var string
      *
-     * @ES\Property(type="string", name="_ttl")
+     * @ES\MetaField(name="_ttl")
      */
     public $ttl;
 

--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -85,35 +85,38 @@ class Converter
     public function assignArrayToObject(array $array, $object, array $aliases)
     {
         foreach ($array as $name => $value) {
-            if (!isset($aliases[$name]['type'])) {
+            if (!isset($aliases[$name])) {
                 continue;
             }
-            switch ($aliases[$name]['type']) {
-                case 'date':
-                    $value = \DateTime::createFromFormat(
-                        isset($aliases[$name]['format']) ? $aliases[$name]['format'] : \DateTime::ISO8601,
-                        $value
-                    );
-                    break;
-                case 'object':
-                case 'nested':
-                    if ($aliases[$name]['multiple']) {
-                        $value = new ObjectIterator($this, $value, $aliases[$name]);
-                    } else {
-                        if (!isset($value)) {
-                            $value = new ObjectIterator($this, $value, $aliases[$name]);
-                            break;
-                        }
-                        $value = $this->assignArrayToObject(
-                            $value,
-                            new $aliases[$name]['namespace'](),
-                            $aliases[$name]['aliases']
+
+            if (isset($aliases[$name]['type'])) {
+                switch ($aliases[$name]['type']) {
+                    case 'date':
+                        $value = \DateTime::createFromFormat(
+                            isset($aliases[$name]['format']) ? $aliases[$name]['format'] : \DateTime::ISO8601,
+                            $value
                         );
-                    }
-                    break;
-                default:
-                    // Do nothing here. Default cas is required by our code style standard.
-                    break;
+                        break;
+                    case 'object':
+                    case 'nested':
+                        if ($aliases[$name]['multiple']) {
+                            $value = new ObjectIterator($this, $value, $aliases[$name]);
+                        } else {
+                            if (!isset($value)) {
+                                $value = new ObjectIterator($this, $value, $aliases[$name]);
+                                break;
+                            }
+                            $value = $this->assignArrayToObject(
+                                $value,
+                                new $aliases[$name]['namespace'](),
+                                $aliases[$name]['aliases']
+                            );
+                        }
+                        break;
+                    default:
+                        // Do nothing here. Default cas is required by our code style standard.
+                        break;
+                }
             }
 
             if ($aliases[$name]['propertyType'] == 'private') {

--- a/Tests/Functional/Mapping/MetadataCollectorTest.php
+++ b/Tests/Functional/Mapping/MetadataCollectorTest.php
@@ -50,4 +50,24 @@ class MetadataCollectorTest extends WebTestCase
     {
         $this->metadataCollector->getBundleMapping('acme');
     }
+
+    /**
+     * Test for getBundleMapping(). Make sure meta fields are excluded from mapping.
+     */
+    public function testGetBundleMapping()
+    {
+        $mapping = $this->metadataCollector->getBundleMapping('AcmeBarBundle');
+
+        $properties = $mapping['product']['properties'];
+        $this->assertArrayNotHasKey('_id', $properties);
+        $this->assertArrayNotHasKey('_score', $properties);
+        $this->assertArrayNotHasKey('_ttl', $properties);
+        $this->assertArrayNotHasKey('_parent', $properties);
+
+        $aliases = $mapping['product']['aliases'];
+        $this->assertArrayHasKey('_id', $aliases);
+        $this->assertArrayHasKey('_score', $aliases);
+        $this->assertArrayHasKey('_ttl', $aliases);
+        $this->assertArrayHasKey('_parent', $aliases);
+    }
 }


### PR DESCRIPTION
Added new annotation `MetaField` for Elasticsearch meta fields (`_id`, `_ttl`, `_parent`, etc).

This annotation helps to detect meta fields and ensure that they are not included in mapping information.

Closes #493