### PR TITLE
Drop multi type repository support

### DIFF
--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -72,7 +72,7 @@ class MappingPass implements CompilerPassInterface
             foreach ($mappings as $repositoryType => $repositoryDetails) {
                 $repositoryDefinition = new Definition(
                     $container->getParameter('es.repository.class'),
-                    [$repositoryDetails['bundle'].':'.$repositoryDetails['class']]
+                    [$repositoryDetails['namespace']]
                 );
                 $repositoryDefinition->setFactory(
                     [

--- a/Mapping/MetadataCollector.php
+++ b/Mapping/MetadataCollector.php
@@ -209,11 +209,13 @@ class MetadataCollector
      */
     public function getMappingByNamespace($namespace)
     {
+        $namespace = $this->getClassName($namespace);
+
         if (isset($this->mappings[$namespace])) {
             return $this->mappings[$namespace];
         }
 
-        $mapping = $this->getDocumentReflectionMapping(new \ReflectionClass($this->finder->getNamespace($namespace)));
+        $mapping = $this->getDocumentReflectionMapping(new \ReflectionClass($namespace));
         $this->cacheBundle($namespace, $mapping);
 
         return $mapping;
@@ -308,5 +310,17 @@ class MetadataCollector
             $this->mappings[$bundle] = $mapping;
             $this->cache->save('ongr.metadata.mappings', $this->mappings);
         }
+    }
+
+    /**
+     * Returns fully qualified class name.
+     *
+     * @param string $className
+     *
+     * @return string
+     */
+    public function getClassName($className)
+    {
+        return $this->finder->getNamespace($className);
     }
 }

--- a/Resources/doc/find_functions.md
+++ b/Resources/doc/find_functions.md
@@ -17,18 +17,6 @@ $content = $repo->find(1); // 5 is the document _uid in the elasticsearch.
 
 ```
 
-> Important: with `$repo` you an initiate binding to more than one repository (elasticsearch type). `find()` function works only if there is one elasticsearch type loaded otherwise you will get logic exception.
-
-e.g.
-
-```php
-
-$manager = $this->get('es.manager');
-$repo = $manager->getRepository(['AppBundle:User', 'AppBundle:Content']);
-$result = $repo->find(1); // Throws \LogicException
-
-```
-
 By default the response will be a `Document` object which is mapped to certain type you are searching. There is possible to change a result type to an array or raw response what is returned from elasticsearch.
 
 ```php

--- a/Resources/doc/upgrade.md
+++ b/Resources/doc/upgrade.md
@@ -1,6 +1,5 @@
-# Upgrade info
-
-## Upgrading from v0.10.\* to v1.0.\*
+UPGRADE FROM 0.x to 1.0
+===
 
 #### Breaking changes
 
@@ -16,11 +15,12 @@
 * Mapping annotations was simplified. In the `Document` annotations `Skip` and `Inherit` annotations were removed. In `Property` there are only a `type`, `name`, `multiple`, `objectName` and `options`. From now on all custom fields has to be defined in `options` (e.g. index_analyzer). See [mapping chapter](mapping.md) for more info.
 * `AbstractDocument` and `DocumentInterface` was removed in favor of `DocumentTrait`. We think that document detection should be done via annotation and not by interfaces.
 * MetaField annotation introduced to define fields like `_id`, `_score`, `_parent`, `_ttl` etc.
+* From now on `Repository` always represents single document. To execute search on multiple types use `Manager`.
 
 #### Changes which should not impact the functionality
 
 * Minimum PHP required version now is 5.5
-* Minimum symfony required version now is 2.7
+* Minimum Symfony required version now is 2.7
 * Document Proxy class was completely removed. This should not effect any functionality.
 * Profiler namespace is changed from `DataCollector` to `Profiler`.
 * `findBy` in the Repository now uses `query_string` query instead of terms query.

--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -141,17 +141,23 @@ class Manager
     }
 
     /**
-     * Returns repository with one or several active selected type.
+     * Returns repository by document class.
      *
-     * @param string|string[] $type
+     * @param string $className FQCN or string in Bundle:Document format
      *
      * @return Repository
      */
-    public function getRepository($type)
+    public function getRepository($className)
     {
-        $type = is_array($type) ? $type : [$type];
+        // TODO: add local cache
 
-        return $this->createRepository($type);
+        if (!is_string($className)) {
+            throw new \InvalidArgumentException('Document class must be a string.');
+        }
+
+        $namespace = $this->getMetadataCollector()->getClassName($className);
+
+        return $this->createRepository($namespace);
     }
 
     /**
@@ -209,13 +215,13 @@ class Manager
     /**
      * Creates a repository.
      *
-     * @param array $types
+     * @param string $className
      *
      * @return Repository
      */
-    private function createRepository(array $types)
+    private function createRepository($className)
     {
-        return new Repository($this, $types);
+        return new Repository($this, $className);
     }
 
     /**

--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -89,6 +89,11 @@ class Manager
     private $bulkCount = 0;
 
     /**
+     * @var Repository[] Repository local cache
+     */
+    private $repositories;
+
+    /**
      * @param string            $name              Managers name.
      * @param array             $config            Managers configuration.
      * @param Client            $client
@@ -149,15 +154,20 @@ class Manager
      */
     public function getRepository($className)
     {
-        // TODO: add local cache
-
         if (!is_string($className)) {
             throw new \InvalidArgumentException('Document class must be a string.');
         }
 
         $namespace = $this->getMetadataCollector()->getClassName($className);
 
-        return $this->createRepository($namespace);
+        if (isset($this->repositories[$namespace])) {
+            return $this->repositories[$namespace];
+        }
+
+        $repository = $this->createRepository($namespace);
+        $this->repositories[$namespace] = $repository;
+
+        return $repository;
     }
 
     /**

--- a/Tests/Functional/Annotation/DocumentTest.php
+++ b/Tests/Functional/Annotation/DocumentTest.php
@@ -23,7 +23,7 @@ class DocumentTest extends AbstractElasticsearchTestCase
         $manager = $this->getManager();
         $repo = $manager->getRepository('AcmeBarBundle:Product');
 
-        $type = $repo->getTypes()[0];
+        $type = $repo->getType();
         $mappings = $manager->getClient()->indices()->getMapping(['index' => $manager->getIndexName()]);
 
         $this->assertArrayHasKey($type, $mappings[$manager->getIndexName()]['mappings']);

--- a/Tests/Functional/Service/ManagerTest.php
+++ b/Tests/Functional/Service/ManagerTest.php
@@ -246,4 +246,29 @@ class ManagerTest extends AbstractElasticsearchTestCase
         $manager->setIndexName($uniqueIndexName);
         $this->assertEquals($uniqueIndexName, $manager->getIndexName());
     }
+
+    /**
+     * Test for getRepository(). Check if local cache is working.
+     */
+    public function testGetRepository()
+    {
+        $manager = $this->repository->getManager();
+        $expected = $manager->getRepository('AcmeBarBundle:Product');
+        $repository = $manager->getRepository('AcmeBarBundle:Product');
+
+        $this->assertInstanceOf('ONGR\ElasticsearchBundle\Service\Repository', $repository);
+        $this->assertSame($expected, $repository);
+    }
+
+    /**
+     * Test for getRepository() in case invalid class name given.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage must be a string
+     */
+    public function testGetRepositoryException()
+    {
+        $manager = $this->repository->getManager();
+        $manager->getRepository(12345);
+    }
 }

--- a/Tests/Functional/Service/RepositoryTest.php
+++ b/Tests/Functional/Service/RepositoryTest.php
@@ -298,19 +298,6 @@ class RepositoryTest extends AbstractElasticsearchTestCase
     }
 
     /**
-     * Test repository find method in repo with many types.
-     *
-     * @expectedException \LogicException
-     */
-    public function testFindInMultiTypeRepo()
-    {
-        /** @var Repository $repo */
-        $repo = $this->getManager()->getRepository(['AcmeBarBundle:Product', 'AcmeFooBundle:Customer']);
-
-        $repo->find(1);
-    }
-
-    /**
      * Tests remove method.
      */
     public function testRemove()

--- a/Tests/Unit/DependencyInjection/Compiler/MappingPassTest.php
+++ b/Tests/Unit/DependencyInjection/Compiler/MappingPassTest.php
@@ -11,9 +11,7 @@
 
 namespace ONGR\ElasticsearchBundle\Tests\Unit\DependencyInjection\Compiler;
 
-use MyProject\Proxies\__CG__\stdClass;
 use ONGR\ElasticsearchBundle\DependencyInjection\Compiler\MappingPass;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Unit tests for MappingPass.
@@ -35,6 +33,7 @@ class MappingPassTest extends \PHPUnit_Framework_TestCase
                     'properties' => [],
                     'bundle' => 'AcmeBarBundle',
                     'class' => 'Foo',
+                    'namespace' => 'Acme\BarBundle\Document\Foo',
                 ],
             ]
         );

--- a/Tests/Unit/Service/RepositoryTest.php
+++ b/Tests/Unit/Service/RepositoryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\Unit\Service;
+
+use ONGR\ElasticsearchBundle\Service\Repository;
+
+class RepositoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider for testConstructorException().
+     *
+     * @return array
+     */
+    public function getTestConstructorExceptionData()
+    {
+        return [
+            [
+                12345,
+                '\InvalidArgumentException',
+                'must be a string',
+            ],
+            [
+                'Non\Existing\ClassName',
+                '\InvalidArgumentException',
+                'non-existing class',
+            ],
+        ];
+    }
+
+    /**
+     * @param $className
+     * @param $expectedException
+     * @param $expectedExceptionMessage
+     *
+     * @dataProvider getTestConstructorExceptionData()
+     */
+    public function testConstructorException($className, $expectedException, $expectedExceptionMessage)
+    {
+        $this->setExpectedException($expectedException, $expectedExceptionMessage);
+
+        new Repository(null, $className);
+    }
+}


### PR DESCRIPTION
Part of #487

This PR drops multi type repository support. Because of that now it's impossible to execute query on multiple types. I will create another PR which will allow to execute search on multiple ES types again (using Manager).