### PR TITLE
Introduce Collection class as a holder for multiple objects

### DIFF
--- a/Collection.php
+++ b/Collection.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle;
+
+/**
+ * This class is a holder for collection of objects.
+ */
+class Collection implements \Countable, \Iterator, \ArrayAccess
+{
+    /**
+     * @var array
+     */
+    private $elements = [];
+
+    /**
+     * Constructor.
+     *
+     * @param array $elements
+     */
+    public function __construct(array $elements = [])
+    {
+        $this->elements = $elements;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        return current($this->elements);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next()
+    {
+        next($this->elements);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        return key($this->elements);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid()
+    {
+        return $this->offsetExists($this->key());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        reset($this->elements);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->elements);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        return $this->elements[$offset];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetSet($offset, $value)
+    {
+        if ($offset === null) {
+            $this->elements[] = $value;
+        } else {
+            $this->elements[$offset] = $value;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->elements[$offset]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->elements);
+    }
+}

--- a/Resources/doc/mapping.md
+++ b/Resources/doc/mapping.md
@@ -186,19 +186,41 @@ class ContentMetaObject
 ```
 
 ##### Multiple objects
-As shown in the example, by default only a single object will be saved in the document. If there is necessary to store a multiple objects (array), add `multiple=true`. While initiating a document with multiple items you can simply set an array or any kind of traversable.
+
+As shown in the example, by default only a single object will be saved in the document.
+If there is necessary to store a multiple objects (array), add `multiple=true`. While
+initiating a document with multiple items you need to initialize property with new instance of `Collection`.
 
 ```php
+// src/AppBundle/Document/Content.php
 
-//....
+namespace AppBundle/Document;
+
+use ONGR\ElasticsearchBundle\Annotation as ES;
+use ONGR\ElasticsearchBundle\Collection;
+
 /**
- * @var ContentMetaObject
- *
- * @ES\Embedded(class="AppBundle:ContentMetaObject", multiple="true")
+ * @ES\Document(type="content")
  */
-public $metaObject;
-//....
+class Content
+{
+    // ...
 
+    /**
+     * @var ContentMetaObject[]|Collection
+     *
+     * @ES\Embedded(class="AppBundle:ContentMetaObject", multiple="true")
+     */
+    public $metaObjects;
+    
+    /**
+     * Initialize collection.
+     */
+    public function __construct()
+    {
+        $this->metaObjects = new Collection();
+    }
+}
 ```
 
 Insert action will look like this:
@@ -206,7 +228,8 @@ Insert action will look like this:
 
 <?php
 $content = new Content();
-$content->properties = [new ContentMetaObject(), new ContentMetaObject()];
+$content->metaObjects[] = new ContentMetaObject();
+$content->metaObjects[] = new ContentMetaObject();
 
 $manager->persist($content);
 $manager->commit();

--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -11,6 +11,7 @@
 
 namespace ONGR\ElasticsearchBundle\Result;
 
+use ONGR\ElasticsearchBundle\Collection;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use ONGR\ElasticsearchBundle\Service\Manager;
 
@@ -154,7 +155,7 @@ class Converter
                 if (array_key_exists('aliases', $alias)) {
                     $new = [];
                     if ($alias['multiple']) {
-                        $this->isTraversable($value);
+                        $this->isCollection($aliases[$name]['propertyName'], $value);
                         foreach ($value as $item) {
                             $this->checkVariableType($item, [$alias['namespace']]);
                             $new[] = $this->convertToArray($item, $alias['aliases']);
@@ -199,21 +200,22 @@ class Converter
     }
 
     /**
-     * Check if object is traversable, throw exception otherwise.
+     * Check if value is instance of Collection.
      *
-     * @param mixed $value
-     *
-     * @return bool
+     * @param string $property
+     * @param mixed  $value
      *
      * @throws \InvalidArgumentException
      */
-    private function isTraversable($value)
+    private function isCollection($property, $value)
     {
-        if (!(is_array($value) || (is_object($value) && $value instanceof \Traversable))) {
-            throw new \InvalidArgumentException("Variable isn't traversable, although field is set to multiple.");
-        }
+        if (!$value instanceof Collection) {
+            $got = is_object($value) ? get_class($value) : gettype($value);
 
-        return true;
+            throw new \InvalidArgumentException(
+                sprintf('Value of "%s" property must be an instance of Collection, got %s.', $property, $got)
+            );
+        }
     }
 
     /**

--- a/Result/ObjectIterator.php
+++ b/Result/ObjectIterator.php
@@ -11,33 +11,43 @@
 
 namespace ONGR\ElasticsearchBundle\Result;
 
+use ONGR\ElasticsearchBundle\Collection;
+
 /**
  * ObjectIterator class.
  */
-class ObjectIterator extends AbstractResultsIterator
+class ObjectIterator extends Collection
 {
+    /**
+     * @var Converter
+     */
+    private $converter;
+
     /**
      * @var array Aliases information.
      */
     private $alias;
 
     /**
-     * @var Converter
+     * @var array
      */
-    private $objectConverter;
+    private $rawObjects;
 
     /**
      * Using part of abstract iterator functionality only.
      *
      * @param Converter $converter
-     * @param array     $documents
+     * @param array     $objects
      * @param array     $alias
      */
-    public function __construct($converter, $documents, $alias)
+    public function __construct($converter, $objects, $alias)
     {
-        $this->documents = $documents;
+        $this->converter = $converter;
+        $this->rawObjects = $objects;
         $this->alias = $alias;
-        $this->objectConverter = $converter;
+
+        // Pass array with available keys and no values
+        parent::__construct(array_map(function ($v) { return null; }, $objects));
     }
 
     /**
@@ -45,7 +55,7 @@ class ObjectIterator extends AbstractResultsIterator
      */
     protected function convertDocument(array $document)
     {
-        return $this->objectConverter->assignArrayToObject(
+        return $this->converter->assignArrayToObject(
             $document,
             new $this->alias['namespace'](),
             $this->alias['aliases']
@@ -53,12 +63,20 @@ class ObjectIterator extends AbstractResultsIterator
     }
 
     /**
-     * Return current document count.
-     *
-     * @return int
+     * {@inheritdoc}
      */
-    public function count()
+    public function current()
     {
-        return count($this->documents);
+        $value = parent::current();
+
+        // Generate objects on demand
+        if ($value === null && $this->valid()) {
+            $key = $this->key();
+            $value = $this->convertDocument($this->rawObjects[$key]);
+            $this->rawObjects[$key] = null;
+            $this->offsetSet($key, $value);
+        }
+
+        return $value;
     }
 }

--- a/Result/ObjectIterator.php
+++ b/Result/ObjectIterator.php
@@ -46,8 +46,12 @@ class ObjectIterator extends Collection
         $this->rawObjects = $objects;
         $this->alias = $alias;
 
+        $callback = function ($v) {
+            return null;
+        };
+
         // Pass array with available keys and no values
-        parent::__construct(array_map(function ($v) { return null; }, $objects));
+        parent::__construct(array_map($callback, $objects));
     }
 
     /**

--- a/Tests/Functional/Result/PersistObjectsTest.php
+++ b/Tests/Functional/Result/PersistObjectsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\Functional\Result;
+
+use ONGR\ElasticsearchBundle\Test\AbstractElasticsearchTestCase;
+use ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document\CategoryObject;
+use ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document\Product;
+
+class PersistObjectsTest extends AbstractElasticsearchTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDataArray()
+    {
+        return [
+            'default' => [
+                'product' => [
+                    [
+                        '_id' => 'doc1',
+                        'title' => 'Bar Product',
+                        'related_categories' => [
+                            [
+                                'title' => 'Acme',
+                            ],
+                            [
+                                'title' => 'Bar',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Test if we can add more objects into document's "multiple objects" field.
+     */
+    public function testPersistMultipleObjects()
+    {
+        $manager = $this->getManager();
+
+        $category = new CategoryObject();
+        $category->title = 'Bar Category';
+
+        $category2 = new CategoryObject();
+        $category2->title = 'Baz Category';
+
+        /** @var Product $product */
+        $product = new Product();
+        $product->id = 'foo';
+        $product->title = 'Test Document';
+        $product->relatedCategories[] = $category;
+        $product->relatedCategories[] = $category2;
+
+        $manager->persist($product);
+        $manager->commit();
+
+        $product = $manager->find('AcmeBarBundle:Product', 'doc1');
+        $this->count(2, $product->relatedCategories);
+    }
+
+    /**
+     * Test if we can add more objects into document's "multiple objects" field.
+     */
+    public function testAppendObject()
+    {
+        $manager = $this->getManager();
+
+        /** @var Product $product */
+        $product = $manager->find('AcmeBarBundle:Product', 'doc1');
+
+        $this->count(2, $product->relatedCategories);
+
+        $category = new CategoryObject();
+        $category->title = 'Bar Category';
+        $product->relatedCategories[] = $category;
+
+        $manager->persist($product);
+        $manager->commit();
+
+        $product = $manager->find('AcmeBarBundle:Product', 'doc1');
+
+        $this->count(3, $product->relatedCategories);
+    }
+}

--- a/Tests/Functional/Result/PersistObjectsTest.php
+++ b/Tests/Functional/Result/PersistObjectsTest.php
@@ -55,7 +55,6 @@ class PersistObjectsTest extends AbstractElasticsearchTestCase
         $category2 = new CategoryObject();
         $category2->title = 'Baz Category';
 
-        /** @var Product $product */
         $product = new Product();
         $product->id = 'foo';
         $product->title = 'Test Document';

--- a/Tests/Functional/Service/ManagerTest.php
+++ b/Tests/Functional/Service/ManagerTest.php
@@ -160,7 +160,7 @@ class ManagerTest extends AbstractElasticsearchTestCase
         // Case #1: a single link is set, although field is set to multiple.
         $product = new Product();
         $product->relatedCategories = new CategoryObject();
-        $out[] = [$product, "Variable isn't traversable, although field is set to multiple."];
+        $out[] = [$product, "must be an instance of Collection"];
 
         // Case #2: invalid type of object is set to the field.
         $product = new Product;

--- a/Tests/Functional/Service/RepositoryTest.php
+++ b/Tests/Functional/Service/RepositoryTest.php
@@ -285,7 +285,8 @@ class RepositoryTest extends AbstractElasticsearchTestCase
 
         $result = $repo->find(123);
 
-        $this->assertEquals(get_object_vars($product), get_object_vars($result));
+        $this->assertInstanceOf('ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document\Product', $result);
+        $this->assertEquals($product->getId(), $result->getId());
     }
 
     /**

--- a/Tests/app/fixture/Acme/BarBundle/Document/Product.php
+++ b/Tests/app/fixture/Acme/BarBundle/Document/Product.php
@@ -12,6 +12,7 @@
 namespace ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document;
 
 use ONGR\ElasticsearchBundle\Annotation as ES;
+use ONGR\ElasticsearchBundle\Collection;
 use ONGR\ElasticsearchBundle\Document\DocumentTrait;
 
 /**
@@ -94,4 +95,9 @@ class Product
      * )
      */
     public $tokenPiecesCount;
+
+    public function __construct()
+    {
+        $this->relatedCategories = new Collection();
+    }
 }


### PR DESCRIPTION
This PR adds requirement to use `Collection` for "multiple objects" properties. `ObjectIterator` now extends `Collection`.

Not sure about the naming and namespaces.

Closes #525