### PR TITLE
Update minimal required versions

### DIFF
--- a/Tests/Functional/Result/DocumentScanIteratorTest.php
+++ b/Tests/Functional/Result/DocumentScanIteratorTest.php
@@ -12,7 +12,6 @@
 namespace ONGR\ElasticsearchBundle\Tests\Functional\Result;
 
 use ONGR\ElasticsearchBundle\Result\DocumentIterator;
-use ONGR\ElasticsearchBundle\Service\Repository;
 use ONGR\ElasticsearchBundle\Test\AbstractElasticsearchTestCase;
 use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
 use ONGR\ElasticsearchDSL\Search;

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ongr/elasticsearch-bundle",
-    "description": "Elasticsearch php client bundle for Symfony 2.",
+    "description": "Elasticsearch bundle for Symfony.",
     "type": "symfony-bundle",
     "homepage": "http://ongr.io",
     "license": "MIT",
@@ -16,8 +16,8 @@
         "doctrine/annotations": "~1.2",
         "doctrine/inflector": "~1.0",
         "doctrine/cache": "~1.4",
-        "monolog/monolog": "~1.0",
-        "elasticsearch/elasticsearch": "~2.0",
+        "monolog/monolog": "~1.10",
+        "elasticsearch/elasticsearch": "^2.1.3",
         "ongr/elasticsearch-dsl": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Changed few requirements because lower versions are incompatible. 

In the future in would be nice to run tests on dependencies installed with `--prefer-lowest` flag.