### PR TITLE
Create index and populate data on test setup

### DIFF
--- a/Tests/Functional/Command/IndexExportCommandTest.php
+++ b/Tests/Functional/Command/IndexExportCommandTest.php
@@ -200,8 +200,6 @@ class IndexExportCommandTest extends AbstractElasticsearchTestCase
      */
     public function testIndexExport($options, $expectedResults)
     {
-        $this->getManager($options['--manager']);
-
         $app = new Application();
         $app->add($this->getExportCommand());
 

--- a/Tests/Functional/Command/IndexImportCommandTest.php
+++ b/Tests/Functional/Command/IndexImportCommandTest.php
@@ -58,7 +58,8 @@ class IndexImportCommandTest extends AbstractElasticsearchTestCase
             ]
         );
 
-        $manager = $this->getManager('default', false);
+        $manager = $this->getManager();
+        $manager->dropIndex();
         $repo = $manager->getRepository('AcmeBarBundle:Product');
         $search = $repo
             ->createSearch()

--- a/Tests/Functional/Command/MappingUpdateCommandTest.php
+++ b/Tests/Functional/Command/MappingUpdateCommandTest.php
@@ -26,7 +26,8 @@ class MappingUpdateCommandTest extends AbstractElasticsearchTestCase
      */
     public function testExecute()
     {
-        $manager = $this->getManager('default', true, ['default' => []]);
+        $manager = $this->getManager();
+        $manager->dropAndCreateIndex(true);
 
         $mapping = $manager->getClient()->indices()->getMapping(['index' => $manager->getIndexName()]);
 

--- a/Tests/Functional/Profiler/ElasticsearchProfilerTest.php
+++ b/Tests/Functional/Profiler/ElasticsearchProfilerTest.php
@@ -69,8 +69,7 @@ class ElasticsearchProfilerTest extends AbstractElasticsearchTestCase
     public function testGetTime()
     {
         $manager = $this->getManager();
-        $repository = $manager->getRepository('AcmeBarBundle:Product');
-        $repository->find(3);
+        $manager->find('AcmeBarBundle:Product', 3);
 
         $this->assertGreaterThan(0.0, $this->getCollector()->getTime(), 'Time should be greater than 0ms');
     }
@@ -81,8 +80,7 @@ class ElasticsearchProfilerTest extends AbstractElasticsearchTestCase
     public function testGetQueries()
     {
         $manager = $this->getManager();
-        $repository = $manager->getRepository('AcmeBarBundle:Product');
-        $repository->find(2);
+        $manager->find('AcmeBarBundle:Product', 2);
         $queries = $this->getCollector()->getQueries();
 
         $lastQuery = end($queries[ElasticsearchProfiler::UNDEFINED_ROUTE]);

--- a/Tests/Functional/Result/DocumentScanIteratorTest.php
+++ b/Tests/Functional/Result/DocumentScanIteratorTest.php
@@ -89,8 +89,7 @@ class DocumentScanIteratorTest extends AbstractElasticsearchTestCase
     {
         $iterator = $this
             ->getManager()
-            ->getRepository('AcmeBarBundle:Product')
-            ->execute($search);
+            ->execute(['AcmeBarBundle:Product'], $search);
 
         $this->assertInstanceOf('ONGR\ElasticsearchBundle\Result\DocumentIterator', $iterator);
         $this->assertCount(4, $iterator);

--- a/Tests/Functional/Result/DocumentWithNullObjectFieldTest.php
+++ b/Tests/Functional/Result/DocumentWithNullObjectFieldTest.php
@@ -37,8 +37,7 @@ class DocumentNullObjectFieldTest extends AbstractElasticsearchTestCase
      */
     public function testResultWithNullObjectField()
     {
-        $repository = $this->getManager()->getRepository('AcmeBarBundle:Place');
-        $document = $repository->find('foo');
+        $document = $this->getManager()->find('AcmeBarBundle:Place', 'foo');
 
         $this->assertInstanceOf(
             'ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document\Place',

--- a/Tests/Functional/Service/RepositoryTest.php
+++ b/Tests/Functional/Service/RepositoryTest.php
@@ -411,7 +411,7 @@ class RepositoryTest extends AbstractElasticsearchTestCase
     {
         $manager = $this->getManager();
         $repository = $manager->getRepository('AcmeBarBundle:Product');
-        $this->assertEquals($manager, $repository->getManager());
+        $this->assertSame($manager, $repository->getManager());
     }
 
     /**


### PR DESCRIPTION
Changed default behaviour in order to simplify usage. If user does not want to create index and populate data on each test he can overwrite `setup()` method.

Closes #452