### PR TITLE
[Bugfix] Dont set filtered query into endpoint during normalization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,6 @@ install:
   - "echo 'script.disable_dynamic: false' | sudo tee -a /etc/elasticsearch/elasticsearch.yml"
   - "echo 'index.warmer.enabled: true' | sudo tee -a /etc/elasticsearch/elasticsearch.yml"
   - sudo service elasticsearch restart
-  - sudo pip install -q sphinx
-  - wget -q -O conf.py https://raw.githubusercontent.com/ongr-io/docs-aggregator/master/source/conf-travis.py
-
 before_script:
   - if [[ $TRAVIS_PHP_VERSION = 5.6 && $ELASTICSEARCH = 1.4.4 ]]; then COVERAGE_NEEDED=true; else COVERAGE_NEEDED=false; fi
   - if [[ $COVERAGE_NEEDED = false ]]; then phpenv config-rm xdebug.ini || true; fi
@@ -36,10 +33,8 @@ before_script:
 script:
   - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
   - vendor/bin/phpcs -p --standard=$TRAVIS_BUILD_DIR/vendor/ongr/ongr-strict-standard/Ongr --ignore=vendor/,Tests/app/,Test/ElasticsearchTestCase.php ./
-  - sphinx-build -nWq -b html -c . Resources/doc _build/html
 
 after_script:
-  - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && wget --post-data="" -q -O /dev/null http://readthedocs.org/build/ongr'
   - >
     if [[ $COVERAGE_NEEDED = true ]]; then
         wget https://scrutinizer-ci.com/ocular.phar;

--- a/DSL/SearchEndpoint/QueryEndpoint.php
+++ b/DSL/SearchEndpoint/QueryEndpoint.php
@@ -67,28 +67,27 @@ class QueryEndpoint extends AbstractSearchEndpoint implements OrderedNormalizerI
     public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
         $isRelevant = false;
+        $builder = $this->getBuilder();
 
         if ($this->hasReference('filtered_query')) {
             /** @var FilteredQuery $query */
             $query = $this->getReference('filtered_query');
-            if ($this->getBuilder()) {
-                $query->setQuery($this->getBuilder());
+            if ($builder) {
+                $query->setQuery($builder);
             }
-            $this->setBuilder($query);
+            $builder = $query;
             $isRelevant = true;
         }
 
-        if ($this->getBuilder()) {
-            if (method_exists($this->getBuilder(), 'setParameters') && count($this->getParameters()) > 0) {
-                $this
-                    ->getBuilder()
-                    ->setParameters($this->processArray($this->getBuilder()->getParameters()));
+        if ($builder) {
+            if (method_exists($builder, 'setParameters') && count($this->getParameters()) > 0) {
+                $builder->setParameters($this->processArray($builder->getParameters()));
             }
 
             $isRelevant = true;
         }
 
-        return $isRelevant ? [$this->getBuilder()->getType() => $this->getBuilder()->toArray()] : null;
+        return $isRelevant ? [$builder->getType() => $builder->toArray()] : null;
     }
 
     /**


### PR DESCRIPTION
If same search happens to be executed twice, then in second query we would see filtered query within a filtered query with same filters.

This issue also slows down query execution time.

** EDITED **