### PR TITLE
Throw exception when document parsing fails

### DIFF
--- a/Mapping/Caser.php
+++ b/Mapping/Caser.php
@@ -19,7 +19,7 @@ use Doctrine\Common\Inflector\Inflector;
 class Caser
 {
     /**
-     * Transforms string to camel case.
+     * Transforms string to camel case (e.g., resultString).
      *
      * @param string $string Text to transform.
      *
@@ -31,7 +31,7 @@ class Caser
     }
 
     /**
-     * Transforms string to snake case.
+     * Transforms string to snake case (e.g., result_string).
      *
      * @param string $string Text to transform.
      *

--- a/Mapping/Exception/DocumentParserException.php
+++ b/Mapping/Exception/DocumentParserException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Mapping\Exception;
+
+/**
+ * This is the exception which should be thrown when document has invalid or incomplete annotations.
+ */
+class DocumentParserException extends \Exception
+{
+}

--- a/Mapping/Exception/MissingDocumentAnnotationException.php
+++ b/Mapping/Exception/MissingDocumentAnnotationException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Mapping\Exception;
+
+/**
+ * This is the exception which should be thrown when class does not have @Document annotation.
+ */
+class MissingDocumentAnnotationException extends DocumentParserException
+{
+}

--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -228,17 +228,12 @@ class Converter
      * @param object $document
      *
      * @return array
-     *
-     * @throws \DomainException
      */
     private function getAlias($document)
     {
         $class = get_class($document);
         $documentMapping = $this->metadataCollector->getMapping($class);
-        if (is_array($documentMapping) && isset($documentMapping['aliases'])) {
-            return $documentMapping['aliases'];
-        }
 
-        throw new \DomainException("Aliases could not be found for {$class} document.");
+        return $documentMapping['aliases'];
     }
 }

--- a/Tests/Functional/Mapping/MetadataCollectorTest.php
+++ b/Tests/Functional/Mapping/MetadataCollectorTest.php
@@ -70,8 +70,8 @@ class MetadataCollectorTest extends WebTestCase
     /**
      * Test for getDocumentType() in case invalid class given.
      *
-     * @expectedException \Exception
-     * @expectedExceptionMessage Mapping for class "\StdClass" was not found
+     * @expectedException \ONGR\ElasticsearchBundle\Mapping\Exception\MissingDocumentAnnotationException
+     * @expectedExceptionMessage cannot be parsed as document because @Document annotation is missing
      */
     public function testGetDocumentTypeException()
     {


### PR DESCRIPTION
Introduced exceptions in document parser which is a MUST. Later this will help to refactor `DocumentParser` without breaking BC.

This PR also changes behaviour how type name is generated when not provided by user. Now it's converted to snake_case to be consistent with generated property names logic.