### PR TITLE
Profiler timing fix

### DIFF
--- a/DataCollector/ElasticsearchDataCollector.php
+++ b/DataCollector/ElasticsearchDataCollector.php
@@ -82,7 +82,7 @@ class ElasticsearchDataCollector implements DataCollectorInterface
      */
     public function getTime()
     {
-        return round($this->time * 100, 2);
+        return round($this->time * 1000, 2);
     }
 
     /**
@@ -179,7 +179,7 @@ class ElasticsearchDataCollector implements DataCollectorInterface
                 'body' => $body !== null ? json_encode($body, JSON_PRETTY_PRINT) : '',
                 'method' => $record['context']['method'],
                 'httpParameters' => $httpParameters,
-                'time' => $record['context']['duration'] * 100,
+                'time' => $record['context']['duration'] * 1000,
             ],
             array_diff_key(parse_url($record['context']['uri']), array_flip(['query']))
         );


### PR DESCRIPTION
Elasticsearch client returns time in seconds and 1 second has 1000 ms not 100 :)

IDK about the newer version though.