### PR TITLE
Makes the Converter respect stange date formats

### DIFF
--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -91,10 +91,9 @@ class Converter
             if (isset($aliases[$name]['type'])) {
                 switch ($aliases[$name]['type']) {
                     case 'date':
-                        $value = \DateTime::createFromFormat(
-                            isset($aliases[$name]['format']) ? $aliases[$name]['format'] : \DateTime::ISO8601,
-                            $value
-                        );
+                        $epoch = strtotime($value);
+                        $value = new \DateTime();
+                        $value->setTimestamp($epoch);
                         break;
                     case 'object':
                     case 'nested':


### PR DESCRIPTION
The dates I store in elastic are formatted as follows:
 
```php
/**
  * @ES\Property(type="date", options={"format": "Y-M-D'T'HH:mm:ss"})
  */
  public $start;
```

Before this change they are Converted as `false`.

After this change, they are correctly converted into `\DateTime` objects.