### PR TITLE
Add the "none" commit mode to disable both refresh and flush

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -171,7 +171,7 @@ class Configuration implements ConfigurationInterface
                         )
                     ->end()
                     ->enumNode('commit_mode')
-                        ->values(['refresh', 'flush'])
+                        ->values(['refresh', 'flush', 'none'])
                         ->defaultValue('refresh')
                         ->info(
                             'The type of commit to the elasticsearch'

--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -205,10 +205,10 @@ class Manager
      */
     public function setCommitMode($commitMode)
     {
-        if ($commitMode === 'refresh' || $commitMode === 'flush') {
+        if ($commitMode === 'refresh' || $commitMode === 'flush' || $commitMode === 'none') {
             $this->commitMode = $commitMode;
         } else {
-            throw new \LogicException('The commit method must be either refresh or flush.');
+            throw new \LogicException('The commit method must be either refresh, flush or none.');
         }
     }
 
@@ -342,7 +342,6 @@ class Manager
                     $this->flush($params);
                     break;
                 case 'refresh':
-                default:
                     $this->refresh($params);
                     break;
             }


### PR DESCRIPTION
When doing heavy indexation on Elasticsearch,
it's a common practice to disable the refresh completely to improve performances.

- https://www.elastic.co/guide/en/elasticsearch/guide/current/near-real-time.html
- http://blog.sematext.com/2013/07/08/elasticsearch-refresh-interval-vs-indexing-performance/

This was not possible via this bundle until now :)

It's also not recommended to force manual refresh on each indexation.