### PR TITLE
Added sub-folder for elasticsearch mappings cache 

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -14,7 +14,7 @@ services:
 
     es.cache_engine:
         class: Doctrine\Common\Cache\FilesystemCache
-        arguments: ["%kernel.cache_dir%/ongr", ".ongr.data"]
+        arguments: ["%kernel.cache_dir%/ongr/elasticsearch", ".ongr.data"]
 
     annotations.cached_reader:
         class: Doctrine\Common\Annotations\CachedReader


### PR DESCRIPTION
Elasticsearch bundle uses Filesystem cache while other bundles are using PHP templates and different cache types with the same doctrine cache library. Sometimes it conflicts in between. 