### PR TITLE
Implemented setting an id to persisted objects

### DIFF
--- a/DependencyInjection/ONGRElasticsearchExtension.php
+++ b/DependencyInjection/ONGRElasticsearchExtension.php
@@ -48,6 +48,7 @@ class ONGRElasticsearchExtension extends Extension
                 $container->getParameter('kernel.debug') ? new Reference('es.tracer') : null,
             ]
         );
+        $definition->addMethodCall('setEventDispatcher', [new Reference('event_dispatcher')]);
         $container->setDefinition('es.manager_factory', $definition);
     }
 }

--- a/Event/BulkEvent.php
+++ b/Event/BulkEvent.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class BulkEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $operation;
+
+    /**
+     * @var string|array
+     */
+    private $type;
+
+    /**
+     * @var array
+     */
+    private $query;
+
+    /**
+     * @param string       $operation
+     * @param string|array $type
+     * @param array        $query
+     */
+    public function __construct($operation, $type, array $query)
+    {
+        $this->type = $type;
+        $this->query = $query;
+        $this->operation = $operation;
+    }
+
+    /**
+     * @return array|string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOperation()
+    {
+        return $this->operation;
+    }
+}

--- a/Event/CommitEvent.php
+++ b/Event/CommitEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class CommitEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $commitMode;
+
+    /**
+     * @var array
+     */
+    private $bulkParams;
+
+    /**
+     * @param string $commitMode
+     * @param array|null  $bulkParams BulkQueries or BulkResponse, depending on event
+     */
+    public function __construct($commitMode, $bulkParams = [])
+    {
+        $this->commitMode = $commitMode;
+        $this->bulkParams = $bulkParams;
+    }
+
+    /**
+     * Returns commit mode
+     *
+     * @return string
+     */
+    public function getCommitMode()
+    {
+        return $this->commitMode;
+    }
+
+    /**
+     * Returns params
+     *
+     * @return array
+     */
+    public function getBulkParams()
+    {
+        return $this->bulkParams;
+    }
+}

--- a/Event/Events.php
+++ b/Event/Events.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Event;
+
+/**
+ * Contains all events thrown in the ONGRElasticsearchBundle
+ */
+final class Events
+{
+    /**
+     * The BULK event occurs before during the processing of bulk method
+     */
+    const BULK = 'es.pre_index';
+
+    /**
+     * The PRE_COMMIT event occurs before committing queries to ES
+     */
+    const PRE_COMMIT = 'es.pre_commit';
+
+    /**
+     * The POST_COMMIT event occurs after committing queries to ES
+     */
+    const POST_COMMIT = 'es.post_commit';
+
+    /**
+     * The PERSIST event occurs when passing a document to a managers persist method
+     */
+    const PERSIST = 'es.persist';
+}

--- a/Event/PersistEvent.php
+++ b/Event/PersistEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class PersistEvent extends Event
+{
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * @param object $document object of the document being persisted
+     */
+    public function __construct($document)
+    {
+        $this->document = $document;
+    }
+
+    /**
+     * @return object
+     */
+    public function getDocument()
+    {
+        return $this->document;
+    }
+}

--- a/EventListener/DocumentIdsListener.php
+++ b/EventListener/DocumentIdsListener.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\EventListener;
+
+use ONGR\ElasticsearchBundle\Event\CommitEvent;
+use ONGR\ElasticsearchBundle\Event\PersistEvent;
+use ONGR\ElasticsearchBundle\Service\IdSetter;
+
+class DocumentIdsListener
+{
+    /**
+     * @var IdSetter $setter
+     */
+    private $setter;
+
+    /**
+     * @param IdSetter $setter
+     */
+    public function __construct(IdSetter $setter)
+    {
+        $this->setter = $setter;
+    }
+
+    /**
+     * @param PersistEvent $event
+     */
+    public function onEsPersist(PersistEvent $event)
+    {
+        $this->setter->persist($event->getDocument());
+    }
+
+
+    public function onESPostCommit(CommitEvent $event)
+    {
+        $this->setter->addIds($event->getBulkParams());
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -64,6 +64,17 @@ services:
         tags:
             - { name: kernel.event_listener, event: kernel.terminate }
 
+    es.document_ids_listener:
+        class: ONGR\ElasticsearchBundle\EventListener\DocumentIdsListener
+        arguments: ["@es.document_ids_setter"]
+        tags:
+            - { name: kernel.event_listener, event: es.persist, method: onEsPersist }
+            - { name: kernel.event_listener, event: es.post_commit, method: onEsPostCommit }
+
+    es.document_ids_setter:
+        class: ONGR\ElasticsearchBundle\Service\IdSetter
+        arguments: ["@es.metadata_collector"]
+
     es.generator.document:
         class: ONGR\ElasticsearchBundle\Generator\DocumentGenerator
 

--- a/Service/IdSetter.php
+++ b/Service/IdSetter.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Service;
+
+use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
+
+/**
+ * Sets ids to persisted documents
+ */
+class IdSetter
+{
+    /**
+     * Documents that are added to bulk
+     * @var object[]
+     */
+    private $persistedDocuments;
+
+    /**
+     * Mappings of the persisted documents types
+     * @var array
+     */
+    private $mappings;
+
+    /**
+     * @var MetadataCollector
+     */
+    private $collector;
+
+    public function __construct(MetadataCollector $collector)
+    {
+        $this->collector = $collector;
+    }
+
+    /**
+     * @param object $document
+     */
+    public function persist($document)
+    {
+        $class = get_class($document);
+
+        if (!isset($this->mappings[$class])) {
+            $this->mappings[$class] = $this->collector->getMapping($class)['aliases']['_id'];
+        }
+
+        $idMapping = $this->mappings[$class];
+
+        if ($idMapping['propertyType'] == 'public') {
+            $property = $idMapping['propertyName'];
+            $id = $document->$property;
+        } else {
+            $method = $idMapping['methods']['getter'];
+            $id = $document->$method();
+        }
+
+        if (!$id) {
+            $this->persistedDocuments[] = $document;
+        }
+    }
+
+    /**
+     * @param array $response
+     */
+    public function addIds(array $response)
+    {
+        if (empty($this->persistedDocuments) || $response['errors']) {
+            return;
+        }
+
+        foreach ($response['items'] as $object) {
+            if (isset($object['create'])) {
+                $document = array_shift($this->persistedDocuments);
+                $this->setId($document, $object['create']['_id']);
+            }
+        }
+    }
+
+    /**
+     * @param object $document
+     * @param string $id
+     */
+    private function setId($document, $id)
+    {
+        $class = get_class($document);
+
+        $idMapping = $this->mappings[$class];
+
+        if ($idMapping['propertyType'] == 'public') {
+            $property = $idMapping['propertyName'];
+            $document->$property = $id;
+        } else {
+            $method = $idMapping['methods']['setter'];
+            $document->$method($id);
+        }
+    }
+}

--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -13,6 +13,10 @@ namespace ONGR\ElasticsearchBundle\Service;
 
 use Elasticsearch\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
+use ONGR\ElasticsearchBundle\Event\Events;
+use ONGR\ElasticsearchBundle\Event\BulkEvent;
+use ONGR\ElasticsearchBundle\Event\PersistEvent;
+use ONGR\ElasticsearchBundle\Event\CommitEvent;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use ONGR\ElasticsearchBundle\Result\AbstractResultsIterator;
 use ONGR\ElasticsearchBundle\Result\Converter;
@@ -20,6 +24,7 @@ use ONGR\ElasticsearchBundle\Result\DocumentIterator;
 use ONGR\ElasticsearchBundle\Result\RawIterator;
 use ONGR\ElasticsearchBundle\Result\Result;
 use ONGR\ElasticsearchDSL\Search;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Manager class.
@@ -94,6 +99,11 @@ class Manager
     private $repositories;
 
     /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
      * @param string            $name              Manager name
      * @param array             $config            Manager configuration
      * @param Client            $client
@@ -141,6 +151,14 @@ class Manager
     public function getConfig()
     {
         return $this->config;
+    }
+
+    /**
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -265,6 +283,8 @@ class Manager
         $documentArray = $this->converter->convertToArray($document);
         $type = $this->getMetadataCollector()->getDocumentType(get_class($document));
 
+        $this->eventDispatcher->dispatch(Events::PERSIST, new PersistEvent($document));
+
         $this->bulk('index', $type, $documentArray);
     }
 
@@ -324,6 +344,11 @@ class Manager
         if (!empty($this->bulkQueries)) {
             $bulkQueries = array_merge($this->bulkQueries, $this->bulkParams);
 
+            $this->eventDispatcher->dispatch(
+                Events::PRE_COMMIT,
+                new CommitEvent($this->getCommitMode(), $bulkQueries)
+            );
+
             $bulkResponse = $this->client->bulk($bulkQueries);
             $this->bulkQueries = [];
             $this->bulkCount = 0;
@@ -336,6 +361,11 @@ class Manager
                     $this->refresh($params);
                     break;
             }
+
+            $this->eventDispatcher->dispatch(
+                Events::POST_COMMIT,
+                new CommitEvent($this->getCommitMode(), $bulkResponse)
+            );
 
             return $bulkResponse;
         }
@@ -359,6 +389,11 @@ class Manager
         if (!in_array($operation, ['index', 'create', 'update', 'delete'])) {
             throw new \InvalidArgumentException('Wrong bulk operation selected');
         }
+
+        $this->eventDispatcher->dispatch(
+            Events::BULK,
+            new BulkEvent($operation, $type, $query)
+        );
 
         $this->bulkQueries['body'][] = [
             $operation => array_filter(

--- a/Service/ManagerFactory.php
+++ b/Service/ManagerFactory.php
@@ -15,6 +15,7 @@ use Elasticsearch\ClientBuilder;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use ONGR\ElasticsearchBundle\Result\Converter;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Elasticsearch Manager factory class.
@@ -42,6 +43,11 @@ class ManagerFactory
     private $tracer;
 
     /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
      * @param MetadataCollector $metadataCollector Metadata collector service.
      * @param Converter         $converter         Converter service to transform arrays to objects and visa versa.
      * @param LoggerInterface   $tracer
@@ -53,6 +59,14 @@ class ManagerFactory
         $this->converter = $converter;
         $this->tracer = $tracer;
         $this->logger = $logger;
+    }
+
+    /**
+     * @param EventDispatcherInterface   $eventDispatcher
+     */
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -112,6 +126,7 @@ class ManagerFactory
         );
 
         $manager->setCommitMode($managerConfig['commit_mode']);
+        $manager->setEventDispatcher($this->eventDispatcher);
         $manager->setBulkCommitSize($managerConfig['bulk_size']);
 
         return $manager;

--- a/Tests/Functional/Result/PersistObjectsTest.php
+++ b/Tests/Functional/Result/PersistObjectsTest.php
@@ -13,6 +13,7 @@ namespace ONGR\ElasticsearchBundle\Tests\Functional\Result;
 
 use ONGR\ElasticsearchBundle\Test\AbstractElasticsearchTestCase;
 use ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document\CategoryObject;
+use ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document\Place;
 use ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document\Product;
 use ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document\Person;
 
@@ -176,5 +177,36 @@ class PersistObjectsTest extends AbstractElasticsearchTestCase
 
         $this->assertEquals($product1->getReleased(), $product1FromES->getReleased()->getTimestamp());
         $this->assertEquals(strtotime($product2->getReleased()), $product2FromES->getReleased()->getTimestamp());
+    }
+
+    /**
+     * Test if the id of persisted objects are set
+     */
+    public function testPersistedId()
+    {
+        $manager = $this->getManager();
+
+        $product = new Product();
+        $product->setTitle('foo');
+
+        $product1 = new Product();
+        $product1->setTitle('bar');
+
+        $product2 = new Product();
+        $product2->setTitle('acme');
+        $product2->setId('1');
+
+        $place = new Place();
+        $place->setTitle('location');
+
+        $manager->persist($product);
+        $manager->persist($place);
+        $manager->persist($product2);
+        $manager->persist($product1);
+        $manager->commit();
+
+        $this->assertNotNull($product->getId());
+        $this->assertNotNull($product1->getId());
+        $this->assertEquals('1', $product2->getId());
     }
 }

--- a/Tests/Unit/Event/BulkEventTest.php
+++ b/Tests/Unit/Event/BulkEventTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\Unit\Event;
+
+use ONGR\ElasticsearchBundle\Event\BulkEvent;
+
+class BulkEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetters()
+    {
+        $event = new BulkEvent('index', 'test_type', []);
+
+        $this->assertEquals('test_type', $event->getType());
+        $this->assertEquals('test_type', $event->getType());
+        $this->assertEquals([], $event->getQuery());
+    }
+}

--- a/Tests/Unit/Event/CommitEventTest.php
+++ b/Tests/Unit/Event/CommitEventTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\Unit\Event;
+
+use ONGR\ElasticsearchBundle\Event\CommitEvent;
+
+class CommitEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetters()
+    {
+        $event = new CommitEvent('flush', []);
+
+        $this->assertEquals('flush', $event->getCommitMode());
+        $this->assertEquals([], $event->getBulkParams());
+    }
+}

--- a/Tests/Unit/Event/PersistEventTest.php
+++ b/Tests/Unit/Event/PersistEventTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\Unit\Event;
+
+use ONGR\ElasticsearchBundle\Event\PersistEvent;
+use ONGR\ElasticsearchBundle\Tests\app\fixture\Acme\BarBundle\Document\Product;
+
+class PersistEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetDocument()
+    {
+        $document = new Product();
+        $document->setTitle('foo');
+
+        $event = new PersistEvent($document);
+
+        $this->assertEquals($document, $event->getDocument());
+    }
+}

--- a/Tests/Unit/Service/ManagerFactoryTest.php
+++ b/Tests/Unit/Service/ManagerFactoryTest.php
@@ -28,6 +28,11 @@ class ManagerFactoryTest extends \PHPUnit_Framework_TestCase
         $converter = $this->getMockBuilder('ONGR\ElasticsearchBundle\Result\Converter')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $logger = $this->getMock('Psr\Log\LoggerInterface');
         $managerFactory = new ManagerFactory(
             $metadataCollector,
@@ -35,6 +40,8 @@ class ManagerFactoryTest extends \PHPUnit_Framework_TestCase
             null,
             $logger
         );
+
+        $managerFactory->setEventDispatcher($dispatcher);
 
         $manager = $managerFactory->createManager(
             'test',

--- a/Tests/Unit/Service/ManagerTest.php
+++ b/Tests/Unit/Service/ManagerTest.php
@@ -180,7 +180,12 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $manager = new Manager('test', [], $esClient, ['index' => 'test'], $metadataCollector, $converter);
+        $manager->setEventDispatcher($dispatcher);
 
         foreach ($calls as list($operation, $type, $query)) {
             $manager->bulk($operation, $type, $query);
@@ -211,9 +216,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
+        $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
         $manager = new Manager('test', [], $esClient, ['index' => 'test'], $metadataCollector, $converter);
         $manager->setBulkParams(['refresh' => true]);
         $manager->setCommitMode('flush');
+        $manager->setEventDispatcher($dispatcher);
 
         foreach ($calls as list($operation, $type, $query)) {
             $manager->bulk($operation, $type, $query);


### PR DESCRIPTION
PR should only be merged when the bundle has event dispatching support. The performance testing shows that the speed of indexing is decreased by 20 - 25 % compared to the implementation with event dispatching and ~40% when comparing to a current master branch implementation. My suggestion would be to continue increasing the performance and perhaps introduce a separate config value, that would allow to disable the id functionality when its not needed (during heavy indexing for example).

Closes #484