### PR TITLE
Disable conversion of 'null' date fields

### DIFF
--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -91,6 +91,9 @@ class Converter
             if (isset($aliases[$name]['type'])) {
                 switch ($aliases[$name]['type']) {
                     case 'date':
+                        if (is_null($value)) {
+                            break;
+                        }
                         if (is_numeric($value) && (int)$value == $value) {
                             $time = $value;
                         } else {


### PR DESCRIPTION
I recently had the problem that I worked on some legacy data sources where documents had date typed fields (_e.g. deletedDate_) set to `null`.

After I fetched such documents, these date fields were populated with unwanted `DateTime(0)` instances after converting the results into objects and lead to unexpected behavior or errors.

After adding these three lines the problems were gone and it worked as expected.