### PR TITLE
Made Manager::commit() return ids of persisted objects

### DIFF
--- a/Tests/Functional/Result/PersistObjectsTest.php
+++ b/Tests/Functional/Result/PersistObjectsTest.php
@@ -177,4 +177,32 @@ class PersistObjectsTest extends AbstractElasticsearchTestCase
         $this->assertEquals($product1->getReleased(), $product1FromES->getReleased()->getTimestamp());
         $this->assertEquals(strtotime($product2->getReleased()), $product2FromES->getReleased()->getTimestamp());
     }
+
+    /**
+     * Tests if the ids that are returned by commit() are correct
+     */
+    public function testIdsReturnedByCommit()
+    {
+        $product1 = new Product();
+        $product1->setTitle('foo');
+
+        $product2 = new Product();
+        $product2->setTitle('bar');
+
+        $manager = $this->getManager();
+        $manager->persist($product1);
+        $manager->persist($product2);
+
+        $ids = $manager->commit();
+
+        $this->assertTrue(is_array($ids));
+
+        /** @var Product $product1FromES */
+        $product1FromES = $manager->find('AcmeBarBundle:Product', $ids[0]);
+        /** @var Product $product2FromES */
+        $product2FromES = $manager->find('AcmeBarBundle:Product', $ids[1]);
+
+        $this->assertEquals('foo', $product1FromES->getTitle());
+        $this->assertEquals('bar', $product2FromES->getTitle());
+    }
 }

--- a/Tests/Functional/Service/ManagerTest.php
+++ b/Tests/Functional/Service/ManagerTest.php
@@ -358,4 +358,19 @@ class ManagerTest extends AbstractElasticsearchTestCase
         $search->addQuery(new MatchAllQuery());
         $repo->execute($search, 'non_existant_type');
     }
+
+    /**
+     * Tests the exception thrown by the commit method
+     *
+     * @expectedException \Elasticsearch\Common\Exceptions\ClientErrorResponseException
+     */
+    public function testCommitException()
+    {
+        $manager = $this->getManager();
+        $product = new Product();
+        $product->setTitle(new Product());
+
+        $manager->persist($product);
+        $manager->commit();
+    }
 }

--- a/Tests/Unit/Service/ManagerTest.php
+++ b/Tests/Unit/Service/ManagerTest.php
@@ -166,10 +166,11 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testBulk($expected, $calls)
     {
+        $bulkResponse = ['errors' => false, 'items' => []];
         $indices = $this->getMock('Elasticsearch\Namespaces\IndicesNamespace', [], [], '', false);
 
         $esClient = $this->getMock('Elasticsearch\Client', [], [], '', false);
-        $esClient->expects($this->once())->method('bulk')->with($expected);
+        $esClient->expects($this->once())->method('bulk')->with($expected)->will($this->returnValue($bulkResponse));
         $esClient->expects($this->any())->method('indices')->will($this->returnValue($indices));
 
         $metadataCollector = $this->getMockBuilder('ONGR\ElasticsearchBundle\Mapping\MetadataCollector')
@@ -194,13 +195,14 @@ class ManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testBulkWithCommitModeSet()
     {
+        $bulkResponse = ['errors' => false, 'items' => []];
         $expected = $this->getTestBulkData()['update_script']['expected'];
         $expected['refresh'] = true;
         $calls = $this->getTestBulkData()['update_script']['calls'];
         $indices = $this->getMock('Elasticsearch\Namespaces\IndicesNamespace', [], [], '', false);
 
         $esClient = $this->getMock('Elasticsearch\Client', [], [], '', false);
-        $esClient->expects($this->any())->method('bulk')->with($expected)->willReturn([]);
+        $esClient->expects($this->any())->method('bulk')->with($expected)->willReturn($bulkResponse);
         $esClient->expects($this->any())->method('indices')->will($this->returnValue($indices));
 
         $metadataCollector = $this->getMockBuilder('ONGR\ElasticsearchBundle\Mapping\MetadataCollector')


### PR DESCRIPTION
In addition I implemented throwing of an exception if there is an error in the `bulkResponse`. My only concern here is that currently a check is executed on persisted items to fetch the first occurring error message, but this involves an additional foreach loop. I would appreciate the opinion of others on this.

Closes #470 