### PR TITLE
Fix incorrect profiler query times

### DIFF
--- a/Profiler/ElasticsearchProfiler.php
+++ b/Profiler/ElasticsearchProfiler.php
@@ -179,7 +179,7 @@ class ElasticsearchProfiler implements DataCollectorInterface
                 'body' => $body !== null ? json_encode($body, JSON_PRETTY_PRINT) : '',
                 'method' => $record['context']['method'],
                 'httpParameters' => $httpParameters,
-                'time' => $record['context']['duration'] * 100,
+                'time' => $record['context']['duration'] * 1000,
             ],
             array_diff_key(parse_url($record['context']['uri']), array_flip(['query']))
         );


### PR DESCRIPTION
Hey, I noticed the time reported on the profiler toolbar/sidebar was different than the total of all queries.