### PR TITLE
don't set $params['types'] when $types is empty

### DIFF
--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -277,7 +277,11 @@ class Manager
     {
         $params = [];
         $params['index'] = $this->getIndexName();
-        $params['type'] = implode(',', $types);
+        
+        if (!empty($types)) {
+            $params['type'] = implode(',', $types);
+        }
+        
         $params['body'] = $query;
 
         if (!empty($queryStringParams)) {


### PR DESCRIPTION
If the array $types is empty (while searching on all types), do not set it to empty string in order to avoid elastic client to generate an URI like '/<index>//_search'
