### PR TITLE
no-array-mapping option added to create index

### DIFF
--- a/Command/IndexCreateCommand.php
+++ b/Command/IndexCreateCommand.php
@@ -39,7 +39,18 @@ class IndexCreateCommand extends AbstractManagerAwareCommand
                 InputOption::VALUE_NONE,
                 'If the time suffix is used, its nice to create an alias to the configured index name.'
             )
-            ->addOption('no-mapping', null, InputOption::VALUE_NONE, 'Do not include mapping')
+            ->addOption(
+                'no-mapping',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not include mapping'
+            )
+            ->addOption(
+                'no-array-mappings',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not include array mapping'
+            )
             ->addOption(
                 'if-not-exists',
                 null,
@@ -88,7 +99,7 @@ class IndexCreateCommand extends AbstractManagerAwareCommand
             return 0;
         }
 
-        $manager->createIndex($input->getOption('no-mapping'));
+        $manager->createIndex($input->getOption('no-mapping'), $input->getOption('no-array-mappings'));
 
         $io->text(
             sprintf(


### PR DESCRIPTION
I've been having some issues with using array type data within my ES index.

When I try to create the index on my test machines on travis I get the following error:

```
  [Elasticsearch\Common\Exceptions\BadRequest400Exception]
  {"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"No handler for type [array] declared on fie
  ld [qualifiers]"}],"type":"mapper_parsing_exception","reason":"Failed to parse mapping [statistic]: No handler f
  or type [array] declared on field [qualifiers]","caused_by":{"type":"mapper_parsing_exception","reason":"No hand
  ler for type [array] declared on field [qualifiers]"}},"status":400}
```

There is nothing wrong with the index as you can use array types, but if I need the array type defined in my model to work correctly for indexing and querying. However when attempting to create the index with the CLI tool I get hit by this error.

I might not be the best solution as `--no-array-mapping` on the `ongr:es:index:create` but I cannot see anywhere else in the code to correct this issue.

If there is a known work-around then I'm happy to adjust my code.