### PR TITLE
rename "annotations.cached_reader " service.

### DIFF
--- a/Command/DocumentGenerateCommand.php
+++ b/Command/DocumentGenerateCommand.php
@@ -584,7 +584,7 @@ class DocumentGenerateCommand extends AbstractManagerAwareCommand
 
         return $this
             ->getContainer()
-            ->get('annotations.cached_reader')
+            ->get('es.annotations.cached_reader')
             ->getPropertyAnnotation($reflection->getProperty('type'), 'Doctrine\Common\Annotations\Annotation\Enum')
             ->value;
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -16,7 +16,7 @@ services:
         class: Doctrine\Common\Cache\FilesystemCache
         arguments: ["%kernel.cache_dir%/ongr/elasticsearch", ".ongr.data"]
 
-    annotations.cached_reader:
+    es.annotations.cached_reader:
         class: Doctrine\Common\Annotations\CachedReader
         arguments: ["@annotations.reader", "@es.cache_engine", "%kernel.debug%"]
 
@@ -27,7 +27,7 @@ services:
 
     es.document_parser:
         class: ONGR\ElasticsearchBundle\Mapping\DocumentParser
-        arguments: ["@annotations.cached_reader", "@es.document_finder"]
+        arguments: ["@es.annotations.cached_reader", "@es.document_finder"]
         public: false
 
     es.metadata_collector:


### PR DESCRIPTION
I am seeing very peculiar things happen on my project. All of the annotation cache -- Serializer, Router, Doctrine -- is being written to the cache directory for this bundle.

The service definition has the same name as a private service in Symfony framework. Can you rename it?