### PR TITLE
Fixed namespace in DocumentParserException

### DIFF
--- a/Exception/DocumentParserException.php
+++ b/Exception/DocumentParserException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchBundle\Mapping\Exception;
+namespace ONGR\ElasticsearchBundle\Exception;
 
 /**
  * This is the exception which should be thrown when document has invalid or incomplete annotations.


### PR DESCRIPTION
As reported by Composer:

> Warning: Ambiguous class resolution, "ONGR\ElasticsearchBundle\Mapping\Exception\DocumentParserException" was found in both "vendor/ongr/elasticsearch-bundle/Exception/DocumentParserException.php" and "vendor/ongr/elasticsearch-bundle/Mapping/Exception/DocumentParserException.php", the first will be used.