### PR TITLE
load Embedded metaFields

### DIFF
--- a/Mapping/DocumentParser.php
+++ b/Mapping/DocumentParser.php
@@ -279,7 +279,7 @@ class DocumentParser
                         [
                             'type' => $this->getObjectMapping($type->class)['type'],
                             'multiple' => $type->multiple,
-                            'aliases' => $this->getAliases($child),
+                            'aliases' => $this->getAliases($child, $metaFields),
                             'namespace' => $child->getName(),
                         ]
                     );


### PR DESCRIPTION
if Embedded metaFields are not load on the first pass
cached metaData will be wrong (without _id for exemple)