### PR TITLE
Missing metaFields on embedded property. 

### DIFF
--- a/Mapping/DocumentParser.php
+++ b/Mapping/DocumentParser.php
@@ -283,7 +283,7 @@ class DocumentParser
                         [
                             'type' => $this->getObjectMapping($type->class)['type'],
                             'multiple' => $type->multiple,
-                            'aliases' => $this->getAliases($child),
+                            'aliases' => $this->getAliases($child, $metaFields),
                             'namespace' => $child->getName(),
                         ]
                     );


### PR DESCRIPTION
I have 2 nested entities (SubA, SubB) in one document (MasterA). Metadata is generated in this order: SubA, MasterA, SubB.

SubA is generated using method 'parse', SubB is generated using method 'getAliases'. In the second case the variable $metaFields is missing when the recursion calls getAliases.

So - if the metadata is generated, the first variable is skipped in the nested object (SubB) because of this error. This only happens if the es.cache is set to true.

The result is that if you have more nested entities in one main entity and caching is enabled, the first parameter is present only in the first nested object and in all other following nested objects is missing.

Mysterious bug.