### PR TITLE
Separate dir mapping fix

### DIFF
--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -66,6 +66,11 @@ class MappingPass implements CompilerPassInterface
                     'ONGR\ElasticsearchBundle\Service\Repository',
                     [$repositoryDetails['namespace']]
                 );
+
+                if (isset($repositoryDetails['directory_name']) && $managerName == 'default') {
+                    $container->get('es.document_finder')->setDocumentDir($repositoryDetails['directory_name']);
+                }
+
                 $repositoryDefinition->setFactory(
                     [
                         new Reference(sprintf('es.manager.%s', $managerName)),

--- a/Mapping/DocumentFinder.php
+++ b/Mapping/DocumentFinder.php
@@ -24,7 +24,7 @@ class DocumentFinder
     /**
      * @var string Directory in bundle to load documents from.
      */
-    const DOCUMENT_DIR = 'Document';
+    private $documentDir;
 
     /**
      * Constructor.
@@ -33,7 +33,24 @@ class DocumentFinder
      */
     public function __construct(array $bundles)
     {
+        $this->documentDir = 'Document';
         $this->bundles = $bundles;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDocumentDir()
+    {
+        return $this->documentDir;
+    }
+
+    /**
+     * @param string $documentDir
+     */
+    public function setDocumentDir($documentDir)
+    {
+        $this->documentDir = $documentDir;
     }
 
     /**
@@ -47,7 +64,7 @@ class DocumentFinder
     public function getNamespace($namespace, $documentsDirectory = null)
     {
         if (!$documentsDirectory) {
-            $documentsDirectory = self::DOCUMENT_DIR;
+            $documentsDirectory = $this->documentDir;
         }
 
         if (strpos($namespace, ':') !== false) {
@@ -113,7 +130,7 @@ class DocumentFinder
     public function getBundleDocumentClasses($bundle, $documentsDirectory = null)
     {
         if (!$documentsDirectory) {
-            $documentsDirectory = self::DOCUMENT_DIR;
+            $documentsDirectory = $this->documentDir;
         }
 
         $bundleReflection = new \ReflectionClass($this->getBundleClass($bundle));

--- a/Mapping/DocumentFinder.php
+++ b/Mapping/DocumentFinder.php
@@ -53,6 +53,22 @@ class DocumentFinder
         if (strpos($namespace, ':') !== false) {
             list($bundle, $document) = explode(':', $namespace);
             $bundle = $this->getBundleClass($bundle);
+
+            // If bundle has a sub-namespace it needs to be replaced
+            if (strpos($documentsDirectory, '\\')) {
+                $bundleSubNamespace = substr(
+                    $bundle,
+                    $start = strpos($bundle, '\\') + 1,
+                    strrpos($bundle, '\\') - $start + 1
+                );
+
+                $documentsDirectory = str_replace(
+                    $bundleSubNamespace,
+                    '',
+                    $documentsDirectory
+                );
+            }
+
             $namespace = substr($bundle, 0, strrpos($bundle, '\\')) . '\\' .
                 $documentsDirectory . '\\' . $document;
         }

--- a/Mapping/DocumentParser.php
+++ b/Mapping/DocumentParser.php
@@ -187,10 +187,11 @@ class DocumentParser
      * Returns meta field annotation data from reader.
      *
      * @param \ReflectionProperty $property
+     * @param string              $directory The name of the Document directory in the bundle
      *
      * @return array
      */
-    private function getMetaFieldAnnotationData($property)
+    private function getMetaFieldAnnotationData($property, $directory)
     {
         /** @var MetaField $annotation */
         $annotation = $this->reader->getPropertyAnnotation($property, self::ID_ANNOTATION);
@@ -208,7 +209,7 @@ class DocumentParser
         ];
 
         if ($annotation instanceof ParentDocument) {
-            $data['settings']['type'] = $this->getDocumentType($annotation->class);
+            $data['settings']['type'] = $this->getDocumentType($annotation->class, $directory);
         }
 
         return $data;
@@ -235,6 +236,7 @@ class DocumentParser
     private function getAliases(\ReflectionClass $reflectionClass, array &$metaFields = null)
     {
         $reflectionName = $reflectionClass->getName();
+        $directory = $this->guessDirName($reflectionClass);
 
         // We skip cache in case $metaFields is given. This should not affect performance
         // because for each document this method is called only once. For objects it might
@@ -254,7 +256,7 @@ class DocumentParser
             $type = $type !== null ? $type : $this->getHashMapAnnotationData($property);
 
             if ($type === null && $metaFields !== null
-                && ($metaData = $this->getMetaFieldAnnotationData($property)) !== null) {
+                && ($metaData = $this->getMetaFieldAnnotationData($property, $directory)) !== null) {
                 $metaFields[$metaData['name']] = $metaData['settings'];
                 $type = new \stdClass();
                 $type->name = $metaData['name'];
@@ -299,11 +301,11 @@ class DocumentParser
                 $alias[$type->name]['propertyType'] = $propertyType;
 
                 if ($type instanceof Embedded) {
-                    $child = new \ReflectionClass($this->finder->getNamespace($type->class));
+                    $child = new \ReflectionClass($this->finder->getNamespace($type->class, $directory));
                     $alias[$type->name] = array_merge(
                         $alias[$type->name],
                         [
-                            'type' => $this->getObjectMapping($type->class)['type'],
+                            'type' => $this->getObjectMapping($type->class, $directory)['type'],
                             'multiple' => $type->multiple,
                             'aliases' => $this->getAliases($child),
                             'namespace' => $child->getName(),
@@ -397,13 +399,14 @@ class DocumentParser
     /**
      * Returns document type.
      *
-     * @param string $document Format must be like AcmeBundle:Document.
+     * @param string $document  Format must be like AcmeBundle:Document.
+     * @param string $directory The Document directory name of the bundle.
      *
      * @return string
      */
-    private function getDocumentType($document)
+    private function getDocumentType($document, $directory)
     {
-        $namespace = $this->finder->getNamespace($document);
+        $namespace = $this->finder->getNamespace($document, $directory);
         $reflectionClass = new \ReflectionClass($namespace);
         $document = $this->getDocumentAnnotationData($reflectionClass);
 
@@ -453,6 +456,8 @@ class DocumentParser
     private function getAnalyzers(\ReflectionClass $reflectionClass)
     {
         $analyzers = [];
+        $directory = $this->guessDirName($reflectionClass);
+
         foreach ($this->getDocumentPropertiesReflection($reflectionClass) as $name => $property) {
             $type = $this->getPropertyAnnotationData($property);
             $type = $type !== null ? $type : $this->getEmbeddedAnnotationData($property);
@@ -460,7 +465,7 @@ class DocumentParser
             if ($type instanceof Embedded) {
                 $analyzers = array_merge(
                     $analyzers,
-                    $this->getAnalyzers(new \ReflectionClass($this->finder->getNamespace($type->class)))
+                    $this->getAnalyzers(new \ReflectionClass($this->finder->getNamespace($type->class, $directory)))
                 );
             }
 
@@ -499,6 +504,8 @@ class DocumentParser
     private function getProperties(\ReflectionClass $reflectionClass, $properties = [], $flag = false)
     {
         $mapping = [];
+        $directory = $this->guessDirName($reflectionClass);
+
         /** @var \ReflectionProperty $property */
         foreach ($this->getDocumentPropertiesReflection($reflectionClass) as $name => $property) {
             $type = $this->getPropertyAnnotationData($property);
@@ -516,7 +523,7 @@ class DocumentParser
 
             // Inner object
             if ($type instanceof Embedded) {
-                $map = array_replace_recursive($map, $this->getObjectMapping($type->class));
+                $map = array_replace_recursive($map, $this->getObjectMapping($type->class, $directory));
             }
 
             // HashMap object
@@ -546,12 +553,13 @@ class DocumentParser
      * Loads from cache if it's already loaded.
      *
      * @param string $className
+     * @param string $directory Name of the directory where the Document is
      *
      * @return array
      */
-    private function getObjectMapping($className)
+    private function getObjectMapping($className, $directory)
     {
-        $namespace = $this->finder->getNamespace($className);
+        $namespace = $this->finder->getNamespace($className, $directory);
 
         if (array_key_exists($namespace, $this->objects)) {
             return $this->objects[$namespace];
@@ -581,5 +589,19 @@ class DocumentParser
         ];
 
         return $this->objects[$namespace];
+    }
+
+    /**
+     * @param \ReflectionClass $reflection
+     *
+     * @return string
+     */
+    private function guessDirName(\ReflectionClass $reflection)
+    {
+        return substr(
+            $directory = $reflection->getName(),
+            $start = strpos($directory, '\\') + 1,
+            strrpos($directory, '\\') - $start
+        );
     }
 }

--- a/Mapping/MetadataCollector.php
+++ b/Mapping/MetadataCollector.php
@@ -117,7 +117,7 @@ class MetadataCollector
         }
 
         $mappings = [];
-        $documentDir = isset($config['document_dir']) ? $config['document_dir'] : DocumentFinder::DOCUMENT_DIR;
+        $documentDir = isset($config['document_dir']) ? $config['document_dir'] : $this->finder->getDocumentDir();
 
         // Handle the case when single document mapping requested
         // Usage od ":" in name is deprecated. This if is only for BC.

--- a/Mapping/MetadataCollector.php
+++ b/Mapping/MetadataCollector.php
@@ -356,11 +356,12 @@ class MetadataCollector
      * Returns fully qualified class name.
      *
      * @param string $className
+     * @param string $directory The name of the directory
      *
      * @return string
      */
-    public function getClassName($className)
+    public function getClassName($className, $directory = null)
     {
-        return $this->finder->getNamespace($className);
+        return $this->finder->getNamespace($className, $directory);
     }
 }

--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -183,7 +183,17 @@ class Manager
             throw new \InvalidArgumentException('Document class must be a string.');
         }
 
-        $namespace = $this->getMetadataCollector()->getClassName($className);
+        $directory = null;
+
+        if (strpos($className, ':')) {
+            $bundle = explode(':', $className)[0];
+
+            if (isset($this->config['mappings'][$bundle]['document_dir'])) {
+                $directory = $this->config['mappings'][$bundle]['document_dir'];
+            }
+        }
+
+        $namespace = $this->getMetadataCollector()->getClassName($className, $directory);
 
         if (isset($this->repositories[$namespace])) {
             return $this->repositories[$namespace];

--- a/Tests/Functional/Service/ManagerTest.php
+++ b/Tests/Functional/Service/ManagerTest.php
@@ -340,12 +340,12 @@ class ManagerTest extends AbstractElasticsearchTestCase
     {
         $manager = $this->getManager('custom_dir');
 
-        $variant = new \ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity\Variant();
-        $variant->color = 'green';
+        $category = new \ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity\CategoryObject();
+        $category->title = 'foo';
         $product = new \ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity\Product();
         $product->id = 'custom';
-        $product->description = 'Custom product';
-        $product->variants[] = $variant;
+        $product->title = 'Custom product';
+        $product->categories[] = $category;
         $manager->persist($product);
         $manager->commit();
 
@@ -354,8 +354,8 @@ class ManagerTest extends AbstractElasticsearchTestCase
         $this->assertEquals(get_class($product), $repo->getClassName());
 
         /** @var \ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity\Product $actualProduct */
-        $actualProduct = $repo->findOneBy(['variants.color' => 'green']);
+        $actualProduct = $repo->findOneBy(['categories.title' => 'foo']);
 
-        $this->assertEquals('Custom product', $actualProduct->description);
+        $this->assertEquals('Custom product', $actualProduct->title);
     }
 }

--- a/Tests/Functional/Service/ManagerTest.php
+++ b/Tests/Functional/Service/ManagerTest.php
@@ -340,16 +340,22 @@ class ManagerTest extends AbstractElasticsearchTestCase
     {
         $manager = $this->getManager('custom_dir');
 
+        $variant = new \ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity\Variant();
+        $variant->color = 'green';
         $product = new \ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity\Product();
-        $product->setId('custom');
-        $product->setTitle('Custom product');
+        $product->id = 'custom';
+        $product->description = 'Custom product';
+        $product->variants[] = $variant;
         $manager->persist($product);
         $manager->commit();
 
         $repo = $manager->getRepository('TestBundle:Product');
-        /** @var \ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity\Product $actualProduct */
-        $actualProduct = $repo->find('custom');
 
-        $this->assertEquals('Custom product', $actualProduct->getTitle());
+        $this->assertEquals(get_class($product), $repo->getClassName());
+
+        /** @var \ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity\Product $actualProduct */
+        $actualProduct = $repo->findOneBy(['variants.color' => 'green']);
+
+        $this->assertEquals('Custom product', $actualProduct->description);
     }
 }

--- a/Tests/app/fixture/TestBundle/Entity/CategoryObject.php
+++ b/Tests/app/fixture/TestBundle/Entity/CategoryObject.php
@@ -16,11 +16,11 @@ use ONGR\ElasticsearchBundle\Annotation as ES;
 /**
  * @ES\Object
  */
-class Variant
+class CategoryObject
 {
     /**
      * @var string
      * @ES\Property(type="text", options={"index"="not_analyzed"})
      */
-    public $color;
+    public $title;
 }

--- a/Tests/app/fixture/TestBundle/Entity/Product.php
+++ b/Tests/app/fixture/TestBundle/Entity/Product.php
@@ -12,13 +12,37 @@
 namespace ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity;
 
 use ONGR\ElasticsearchBundle\Annotation as ES;
-use ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Document\Product as BaseProduct;
+use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * Product document for testing.
  *
  * @ES\Document()
  */
-class Product extends BaseProduct
+class Product
 {
+    /**
+     * @var string
+     *
+     * @ES\Id()
+     */
+    public $id;
+
+    /**
+     * @var string|array
+     * @ES\Property(type="text", name="description")
+     */
+    public $description;
+
+    /**
+     * @var Variant[]
+     *
+     * @ES\Embedded(class="TestBundle:Variant", multiple=true)
+     */
+    public $variants;
+
+    public function __construct()
+    {
+        $this->variants = new Collection();
+    }
 }

--- a/Tests/app/fixture/TestBundle/Entity/Product.php
+++ b/Tests/app/fixture/TestBundle/Entity/Product.php
@@ -29,20 +29,20 @@ class Product
     public $id;
 
     /**
-     * @var string|array
-     * @ES\Property(type="text", name="description")
+     * @var string
+     * @ES\Property(type="keyword", name="title")
      */
-    public $description;
+    public $title;
 
     /**
-     * @var Variant[]
+     * @var CategoryObject[]
      *
-     * @ES\Embedded(class="TestBundle:Variant", multiple=true)
+     * @ES\Embedded(class="TestBundle:CategoryObject", multiple=true)
      */
-    public $variants;
+    public $categories;
 
     public function __construct()
     {
-        $this->variants = new Collection();
+        $this->categories = new Collection();
     }
 }

--- a/Tests/app/fixture/TestBundle/Entity/Variant.php
+++ b/Tests/app/fixture/TestBundle/Entity/Variant.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity;
+
+use ONGR\ElasticsearchBundle\Annotation as ES;
+
+/**
+ * @ES\Object
+ */
+class Variant
+{
+    /**
+     * @var string
+     * @ES\Property(type="text", options={"index"="not_analyzed"})
+     */
+    public $color;
+}


### PR DESCRIPTION
This is a potential temporary fix for the problem at hand. It is completely backwards compatible but it only reduces the risk of such an issue, but does not neglect it completely. The problem here is that every manager can potentially have different document directories and the metadata collector and document parser that handle the parsing of annotations are not concerned at all with what manager is being parsed at any given moment. This means that in order to solve this issue the right way, we would have to change the entire concept of how metadata is being handled. 

Either that or I missed something out, if so, let me know. @saimaz what do you think?