### PR TITLE
[BUGFIX] Avoid php warnings when type="object" is used

### DIFF
--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -110,11 +110,13 @@ class Converter
                             if (!isset($value)) {
                                 break;
                             }
-                            $value = $this->assignArrayToObject(
-                                $value,
-                                new $aliases[$name]['namespace'](),
-                                $aliases[$name]['aliases']
-                            );
+                            if (isset($aliases[$name]['namespace']) && isset($aliases[$name]['aliases'])) {
+                                $value = $this->assignArrayToObject(
+                                    $value,
+                                    new $aliases[$name]['namespace'](),
+                                    $aliases[$name]['aliases']
+                                );
+                            }
                         }
                         break;
                     default:

--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -104,7 +104,7 @@ class Converter
                         break;
                     case Object::NAME:
                     case Nested::NAME:
-                        if ($aliases[$name]['multiple']) {
+                        if (isset($aliases[$name]['multiple'])) {
                             $value = new ObjectIterator($this, $value, $aliases[$name]);
                         } else {
                             if (!isset($value)) {


### PR DESCRIPTION
I'am using plain type="object" in my mapping annotation to index simple array structures. I don't need some kind of specified nestet object here, so the only solution is do set type to "object".

Without the fix i got warnings on console. In my dev env and test env warnings are handled as errors, so my app breaks and indexing stops.

This little fix checks if namespace and aliases from reflection stuff is set.