### PR TITLE
Make ObjectIterator compatible with Doctrine Collections

### DIFF
--- a/Collection/Collection.php
+++ b/Collection/Collection.php
@@ -11,107 +11,13 @@
 
 namespace ONGR\ElasticsearchBundle\Collection;
 
+use Doctrine\Common\Collections\ArrayCollection;
+
 /**
  * This class is a holder for collection of objects.
+ *
+ * @deprecated Use Doctrine\Common\Collections\ArrayCollection instead.
  */
-class Collection implements \Countable, \Iterator, \ArrayAccess
+class Collection extends ArrayCollection
 {
-    /**
-     * @var array
-     */
-    private $elements = [];
-
-    /**
-     * Constructor.
-     *
-     * @param array $elements
-     */
-    public function __construct(array $elements = [])
-    {
-        $this->elements = $elements;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function current()
-    {
-        return current($this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function next()
-    {
-        next($this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function key()
-    {
-        return key($this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function valid()
-    {
-        return $this->offsetExists($this->key());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function rewind()
-    {
-        reset($this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetExists($offset)
-    {
-        return array_key_exists($offset, $this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetGet($offset)
-    {
-        return $this->elements[$offset];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetSet($offset, $value)
-    {
-        if ($offset === null) {
-            $this->elements[] = $value;
-        } else {
-            $this->elements[$offset] = $value;
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->elements[$offset]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function count()
-    {
-        return count($this->elements);
-    }
 }

--- a/Resources/doc/mapping.md
+++ b/Resources/doc/mapping.md
@@ -337,7 +337,7 @@ To insert a document with mapping from example above you have to create 2 object
 As shown in the example above, by ElasticsearchBundle default, only a single object will be saved in the document.
 Meanwhile, Elasticsearch database doesn't care if in an object is stored as a single value or as an array. 
 If it is necessary to store multiple objects (array), you have to add `multiple=true` to the annotation. While
-initiating a document with multiple items you need to initialize property with the new instance of `Collection()`.
+initiating a document with multiple items you need to initialize property with the new instance of `ArrayCollection()`.
 
 Here's an example:
 
@@ -346,8 +346,8 @@ Here's an example:
 
 namespace AppBundle\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use ONGR\ElasticsearchBundle\Annotation as ES;
-use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * @ES\Document()
@@ -368,7 +368,7 @@ class Product
     
     public function __construct()
     {
-        $this->variants = new Collection();
+        $this->variants = new ArrayCollection();
     }
     
     /**
@@ -379,7 +379,7 @@ class Product
      */
     public function addVariant(VariantObject $variant)
     {
-        $this->variants[] => $variant;
+        $this->variants[] = $variant;
 
         return $this;
     }

--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -11,9 +11,9 @@
 
 namespace ONGR\ElasticsearchBundle\Result;
 
+use Doctrine\Common\Collections\Collection;
 use ONGR\ElasticsearchBundle\Annotation\Nested;
 use ONGR\ElasticsearchBundle\Annotation\Object;
-use ONGR\ElasticsearchBundle\Collection\Collection;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use ONGR\ElasticsearchBundle\Service\Manager;
 

--- a/Result/ObjectCallbackIterator.php
+++ b/Result/ObjectCallbackIterator.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ONGR\ElasticsearchBundle\Result;
+
+class ObjectCallbackIterator extends \ArrayIterator
+{
+    /**
+     * @var \Closure
+     */
+    private $callback;
+
+    /**
+     * Converts array data to document objects via the callback function.
+     *
+     * @param \Closure $callback
+     * @param array $array
+     */
+    public function __construct(\Closure $callback, array $array = array())
+    {
+        $this->callback = $callback;
+
+        parent::__construct($array);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        $value = parent::current();
+
+        // Generate objects on demand
+        if ($value === null && $this->valid()) {
+            $key = $this->key();
+            $callback = $this->callback;
+            return $callback($key);
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function offsetGet($offset)
+    {
+        $value = parent::offsetGet($offset);
+
+        // Generate objects on demand
+        if ($value === null && $this->valid()) {
+            $callback = $this->callback;
+            return $callback($offset);
+        }
+
+        return $value;
+    }
+}

--- a/Tests/Unit/Collection/CollectionTest.php
+++ b/Tests/Unit/Collection/CollectionTest.php
@@ -11,7 +11,7 @@
 
 namespace ONGR\ElasticsearchBundle\Tests\Unit\Collection;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class CollectionTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,7 +28,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testCountable()
     {
-        $this->assertCount(count($this->data), new Collection($this->data));
+        $this->assertCount(count($this->data), new ArrayCollection($this->data));
     }
 
     /**
@@ -36,7 +36,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testIterator()
     {
-        $this->assertEquals($this->data, iterator_to_array(new Collection($this->data)));
+        $this->assertEquals($this->data, iterator_to_array(new ArrayCollection($this->data)));
     }
 
     /**
@@ -44,7 +44,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testArrayAccess()
     {
-        $collection = new Collection($this->data);
+        $collection = new ArrayCollection($this->data);
 
         $this->assertArrayHasKey('foo', $collection);
         $this->assertEquals($this->data['foo'], $collection['foo']);

--- a/Tests/Unit/Result/ObjectCallbackIteratorTest.php
+++ b/Tests/Unit/Result/ObjectCallbackIteratorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\Unit\Result;
+
+use ONGR\ElasticsearchBundle\Result\ObjectCallbackIterator;
+
+class ObjectCallbackIteratorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests the current method of the iterator uses the callback.
+     */
+    public function testCallbackIteratorCurrent()
+    {
+        $rawData = [null, null, null];
+
+        $callback = function ($key) {
+            return $key;
+        };
+
+        $iterator = new ObjectCallbackIterator($callback, $rawData);
+
+        $this->assertEquals(0, $iterator->current());
+    }
+
+    /**
+     * Tests the offsetGet method of the iterator uses the callback.
+     */
+    public function testCallbackIteratorOffsetGet()
+    {
+        $rawData = [null, null, null];
+
+        $callback = function ($key) {
+            return $key;
+        };
+
+        $iterator = new ObjectCallbackIterator($callback, $rawData);
+
+        $this->assertEquals(1, $iterator->offsetGet(1));
+    }
+
+    /**
+     * Tests iteration of the iterator uses the callback.
+     */
+    public function testCallbackIteratorIteration()
+    {
+        $rawData = [null, null, null];
+
+        $callback = function ($key) {
+            return 'foo';
+        };
+
+        $iterator = new ObjectCallbackIterator($callback, $rawData);
+
+        foreach ($iterator as $item) {
+            $this->assertEquals('foo', $item);
+        }
+    }
+
+    /**
+     * Tests iterator skips the callback for non-null values.
+     */
+    public function testCallbackIteratorUsesValue()
+    {
+        $rawData = [null, 'bar', null];
+
+        $callback = function ($key) {
+            return 'foo';
+        };
+
+        $iterator = new ObjectCallbackIterator($callback, $rawData);
+
+        $this->assertEquals('bar', $iterator[1]);
+    }
+}

--- a/Tests/app/fixture/TestBundle/Document/Product.php
+++ b/Tests/app/fixture/TestBundle/Document/Product.php
@@ -11,8 +11,8 @@
 
 namespace ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use ONGR\ElasticsearchBundle\Annotation as ES;
-use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * Product document for testing.
@@ -117,7 +117,7 @@ class Product
      */
     public function __construct()
     {
-        $this->relatedCategories = new Collection();
+        $this->relatedCategories = new ArrayCollection();
     }
 
     /**

--- a/Tests/app/fixture/TestBundle/Entity/Product.php
+++ b/Tests/app/fixture/TestBundle/Entity/Product.php
@@ -11,8 +11,8 @@
 
 namespace ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use ONGR\ElasticsearchBundle\Annotation as ES;
-use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * Product document for testing.
@@ -43,6 +43,6 @@ class Product
 
     public function __construct()
     {
-        $this->categories = new Collection();
+        $this->categories = new ArrayCollection();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "doctrine/annotations": "~1.2",
         "doctrine/inflector": "~1.0",
         "doctrine/cache": "~1.4",
+        "doctrine/collections": "~1.4",
         "monolog/monolog": "~1.10",
         "ongr/elasticsearch-dsl": "~5.0"
     },


### PR DESCRIPTION
PR to deprecate `ONGR\ElasticsearchBundle\Collection\Collection` in favor of using [doctrine/collections](https://github.com/doctrine/collections).

### doctrine/collections ~1.4

`v1.4` of doctrine/collections introduced the `ArrayCollection::createFrom()` method, which is used internally for immutable actions when new collections are created.  This ensures that common collection projection functions (like `map`, `filter`, etc.) can be used when subclassing `ArrayCollection` to add additional constructor arguments.

### `Converter::isCollection`

`Converter::isCollection()` will check for an instance of the `Doctrine\Common\Collections\Collection` interface, which makes the converter much more flexible in being able to support any object that can act as a collection.  `Collection` is the combination of the interfaces `Countable, IteratorAggregate, ArrayAccess`, so even a custom variation would work with the converter.

### Introduces `ObjectCallbackIterator`( Internal )

Doctrine's `Collection` implements `IteratorAggregate` instead of `Iterator`, so some logic needed to be moved into a custom `Iterator` class that `ObjectIterator` can use for `foreach()`.  

Since `ObjectIterator` converts arrays to objects on-demand, the `ObjectCallbackIterator` returned by `ObjectIterator::getIterator()` gets instantiated with a callback that can do the document conversion and keep the `$rawObjects` list in `ObjectIterator` up-to-date.  This same logic gets applied when `ObjectIterator::offsetGet()` is called, which is why `offsetGet()` needs to be overridden in `ObjectIterator` as well.

`ObjectCallbackIterator` could be marked INTERNAL to make it clear it's not meant to be used on its own.

**Room for Improvement**

If it's not strictly necessary for `ObjectIterator` to hydrate documents one-at-a-time, then this implementation could possibly be replaced by extending [AbstractLazyCollection](https://github.com/doctrine/collections/blob/v1.4.0/lib/Doctrine/Common/Collections/AbstractLazyCollection.php) instead of ArrayCollection, and converting the documents when the collection is initialized, which is (sort of) what Doctrine's [PersistentCollection](https://github.com/doctrine/doctrine2/blob/2.5/lib/Doctrine/ORM/PersistentCollection.php) does in the ORM.

Given that document hydration is tricky at best, I thought it better to leave the implementation working as-is for now.  Type hinting for `Collection` instead of `ArrayCollection`, as I have done in `Converter::isCollection()`, would allow `ObjectIterator` to change transparently later on.


 


Closes #774 