### PR TITLE
Make ObjectIterator an AbstractLazyCollection

### DIFF
--- a/Collection/Collection.php
+++ b/Collection/Collection.php
@@ -11,107 +11,13 @@
 
 namespace ONGR\ElasticsearchBundle\Collection;
 
+use Doctrine\Common\Collections\ArrayCollection;
+
 /**
  * This class is a holder for collection of objects.
+ *
+ * @deprecated Use Doctrine\Common\Collections\ArrayCollection instead.
  */
-class Collection implements \Countable, \Iterator, \ArrayAccess
+class Collection extends ArrayCollection
 {
-    /**
-     * @var array
-     */
-    private $elements = [];
-
-    /**
-     * Constructor.
-     *
-     * @param array $elements
-     */
-    public function __construct(array $elements = [])
-    {
-        $this->elements = $elements;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function current()
-    {
-        return current($this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function next()
-    {
-        next($this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function key()
-    {
-        return key($this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function valid()
-    {
-        return $this->offsetExists($this->key());
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function rewind()
-    {
-        reset($this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetExists($offset)
-    {
-        return array_key_exists($offset, $this->elements);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetGet($offset)
-    {
-        return $this->elements[$offset];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetSet($offset, $value)
-    {
-        if ($offset === null) {
-            $this->elements[] = $value;
-        } else {
-            $this->elements[$offset] = $value;
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->elements[$offset]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function count()
-    {
-        return count($this->elements);
-    }
 }

--- a/Resources/doc/mapping.md
+++ b/Resources/doc/mapping.md
@@ -337,7 +337,7 @@ To insert a document with mapping from example above you have to create 2 object
 As shown in the example above, by ElasticsearchBundle default, only a single object will be saved in the document.
 Meanwhile, Elasticsearch database doesn't care if in an object is stored as a single value or as an array. 
 If it is necessary to store multiple objects (array), you have to add `multiple=true` to the annotation. While
-initiating a document with multiple items you need to initialize property with the new instance of `Collection()`.
+initiating a document with multiple items you need to initialize property with the new instance of `ArrayCollection()`.
 
 Here's an example:
 
@@ -346,8 +346,8 @@ Here's an example:
 
 namespace AppBundle\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use ONGR\ElasticsearchBundle\Annotation as ES;
-use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * @ES\Document()
@@ -368,7 +368,7 @@ class Product
     
     public function __construct()
     {
-        $this->variants = new Collection();
+        $this->variants = new ArrayCollection();
     }
     
     /**
@@ -379,7 +379,7 @@ class Product
      */
     public function addVariant(VariantObject $variant)
     {
-        $this->variants[] => $variant;
+        $this->variants[] = $variant;
 
         return $this;
     }

--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -11,9 +11,9 @@
 
 namespace ONGR\ElasticsearchBundle\Result;
 
+use Doctrine\Common\Collections\Collection;
 use ONGR\ElasticsearchBundle\Annotation\Nested;
 use ONGR\ElasticsearchBundle\Annotation\Object;
-use ONGR\ElasticsearchBundle\Collection\Collection;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use ONGR\ElasticsearchBundle\Service\Manager;
 

--- a/Tests/Unit/Collection/CollectionTest.php
+++ b/Tests/Unit/Collection/CollectionTest.php
@@ -11,7 +11,7 @@
 
 namespace ONGR\ElasticsearchBundle\Tests\Unit\Collection;
 
-use ONGR\ElasticsearchBundle\Collection\Collection;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class CollectionTest extends \PHPUnit_Framework_TestCase
 {
@@ -28,7 +28,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testCountable()
     {
-        $this->assertCount(count($this->data), new Collection($this->data));
+        $this->assertCount(count($this->data), new ArrayCollection($this->data));
     }
 
     /**
@@ -36,7 +36,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testIterator()
     {
-        $this->assertEquals($this->data, iterator_to_array(new Collection($this->data)));
+        $this->assertEquals($this->data, iterator_to_array(new ArrayCollection($this->data)));
     }
 
     /**
@@ -44,7 +44,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testArrayAccess()
     {
-        $collection = new Collection($this->data);
+        $collection = new ArrayCollection($this->data);
 
         $this->assertArrayHasKey('foo', $collection);
         $this->assertEquals($this->data['foo'], $collection['foo']);

--- a/Tests/app/fixture/TestBundle/Document/Product.php
+++ b/Tests/app/fixture/TestBundle/Document/Product.php
@@ -11,8 +11,8 @@
 
 namespace ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Document;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use ONGR\ElasticsearchBundle\Annotation as ES;
-use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * Product document for testing.
@@ -117,7 +117,7 @@ class Product
      */
     public function __construct()
     {
-        $this->relatedCategories = new Collection();
+        $this->relatedCategories = new ArrayCollection();
     }
 
     /**

--- a/Tests/app/fixture/TestBundle/Entity/Product.php
+++ b/Tests/app/fixture/TestBundle/Entity/Product.php
@@ -11,8 +11,8 @@
 
 namespace ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use ONGR\ElasticsearchBundle\Annotation as ES;
-use ONGR\ElasticsearchBundle\Collection\Collection;
 
 /**
  * Product document for testing.
@@ -43,6 +43,6 @@ class Product
 
     public function __construct()
     {
-        $this->categories = new Collection();
+        $this->categories = new ArrayCollection();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "doctrine/annotations": "~1.2",
         "doctrine/inflector": "~1.0",
         "doctrine/cache": "~1.4",
+        "doctrine/collections": "~1.4",
         "monolog/monolog": "~1.10",
         "ongr/elasticsearch-dsl": "~5.0"
     },


### PR DESCRIPTION
In #775 I was able to implement the custom hydration logic into most methods of `ArrayCollection`.  However, numerous methods operate directly on the internal `$elements` object, so keeping that in sync with the `$rawObjects` list becomes cumbersome. Any performance improvement gained from hydrating on-demand is lost as soon as a user wants to run a `map()` or a `filter()` over the collection.

This PR, which could be used in place of #775, implements `ObjectIterator` as an `AbstractLazyCollection`, which will hydrate all the raw data, but only once the data has been requested.  If a document contains a collection, but no operations are ever performed on that collection, no hydration will take place.

Ultimately, this ensures that we avoid any potential side effects associated with performing operations on a document's collection.  It comes at the cost of hydrating all items in the collection once, but for the most common use cases, that cost will likely be incurred during iteration anyway.

Closes #774 