### PR TITLE
Add visibility property when generating a document.

### DIFF
--- a/Command/DocumentGenerateCommand.php
+++ b/Command/DocumentGenerateCommand.php
@@ -170,7 +170,7 @@ class DocumentGenerateCommand extends AbstractManagerAwareCommand
                 continue;
             }
 
-            $this->propertyVisibilities  = ['private', 'protected'];
+            $this->propertyVisibilities  = ['private', 'protected', 'public'];
             $output->writeln($this->getOptionsLabel($this->propertyVisibilities, 'Available visibilities'));
             $property['visibility'] = $this->questionHelper->ask(
                 $input,

--- a/Command/DocumentGenerateCommand.php
+++ b/Command/DocumentGenerateCommand.php
@@ -33,6 +33,11 @@ class DocumentGenerateCommand extends AbstractManagerAwareCommand
     private $propertyAnnotations;
 
     /**
+     * @var string[]
+     */
+    private $propertyVisibilities;
+
+    /**
      * {@inheritdoc}
      */
     protected function configure()
@@ -165,6 +170,19 @@ class DocumentGenerateCommand extends AbstractManagerAwareCommand
                 continue;
             }
 
+            $this->propertyVisibilities  = ['private', 'protected'];
+            $output->writeln($this->getOptionsLabel($this->propertyVisibilities, 'Available visibilities'));
+            $property['visibility'] = $this->questionHelper->ask(
+                $input,
+                $output,
+                $this->getQuestion(
+                    'Property visibility',
+                    'private',
+                    [$this, 'validatePropertyVisibility'],
+                    $this->propertyVisibilities
+                )
+            );
+
             $output->writeln($this->getOptionsLabel($this->propertyAnnotations, 'Available annotations'));
             $property['annotation'] = $this->questionHelper->ask(
                 $input,
@@ -210,7 +228,7 @@ class DocumentGenerateCommand extends AbstractManagerAwareCommand
                         $output,
                         $this->getQuestion(
                             'Property type',
-                            'string',
+                            'text',
                             [$this, 'validatePropertyType'],
                             $this->getPropertyTypes()
                         )
@@ -513,6 +531,26 @@ class DocumentGenerateCommand extends AbstractManagerAwareCommand
         }
 
         return $annotation;
+    }
+
+    /**
+     * Validates property visibility
+     *
+     * @param string $visibility
+     *
+     * @return string
+     * @throws \InvalidArgumentException When the visibility is not found in the list of allowed ones.
+     */
+    public function validatePropertyVisibility($visibility)
+    {
+        if (!in_array($visibility, $this->propertyVisibilities)) {
+            throw $this->getException(
+                'The property visibility isn\'t valid ("%s" given, expecting one of following: %s)',
+                [$visibility, implode(', ', $this->propertyVisibilities)]
+            );
+        }
+
+        return $visibility;
     }
 
     /**

--- a/Generator/DocumentGenerator.php
+++ b/Generator/DocumentGenerator.php
@@ -138,7 +138,7 @@ public function __construct()
 
         foreach ($metadata['properties'] as $property) {
             $lines[] = $this->generatePropertyDocBlock($property);
-            $lines[] = $this->spaces . 'private $' . $property['field_name'] . ";\n";
+            $lines[] = $this->spaces . $property['visibility'] . ' $' . $property['field_name'] . ";\n";
         }
 
         return implode("\n", $lines);
@@ -160,7 +160,7 @@ public function __construct()
             if (isset($property['property_type']) && $property['property_type'] === 'boolean') {
                 $lines[] = $this->generateDocumentMethod($property, $this->isMethodTemplate) . "\n";
             }
-            
+
             $lines[] = $this->generateDocumentMethod($property, $this->getMethodTemplate) . "\n";
         }
 

--- a/Generator/DocumentGenerator.php
+++ b/Generator/DocumentGenerator.php
@@ -156,6 +156,9 @@ public function __construct()
         $lines = [];
 
         foreach ($metadata['properties'] as $property) {
+            if (isset($property['visibility']) && $property['visibility'] === 'public') {
+                continue;
+            }
             $lines[] = $this->generateDocumentMethod($property, $this->setMethodTemplate) . "\n";
             if (isset($property['property_type']) && $property['property_type'] === 'boolean') {
                 $lines[] = $this->generateDocumentMethod($property, $this->isMethodTemplate) . "\n";

--- a/Tests/Unit/Service/GenerateServiceTest.php
+++ b/Tests/Unit/Service/GenerateServiceTest.php
@@ -50,12 +50,14 @@ class GenerateServiceTest extends \PHPUnit_Framework_TestCase
                 [
                     'field_name' => 'test',
                     'annotation' => 'property',
+                    'visibility' => 'private',
                     'property_type' => 'string',
                     'property_name' => 'testProperty',
                     'property_options' => 'test',
                 ],
                 [
                     'field_name' => 'embedded',
+                    'visibility' => 'protected',
                     'annotation' => 'embedded',
                     'property_class' => 'TestBundle:Product',
                     'property_multiple' => true,


### PR DESCRIPTION
This PR adds a visibility for a generated document's field (protected or private) for fixing inheritence from document class.
Also it fixes the default type text for elastic in generation of document.