### PR TITLE
Resolve $types parameters

### DIFF
--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -283,8 +283,13 @@ class Manager
         $params = [];
         $params['index'] = $this->getIndexName();
         
-        if (!empty($types)) {
-            $params['type'] = implode(',', $types);
+        $resolvedTypes = [];
+        foreach ($types as $type) {
+            $resolvedTypes[] = $this->resolveTypeName($type);
+        }
+        
+        if (!empty($resolvedTypes)) {
+            $params['type'] = implode(',', $resolvedTypes);
         }
         
         $params['body'] = $query;


### PR DESCRIPTION
According to the docs, 

```php
$search = new Search();
$search->addQuery(new TermQuery('title', 'Indiana'));

$results = $manager->search(
    // Array of documents representing different types
    ['AppBundle:City', 'AppBundle:State'], 
    $search->toArray()
);
```
but, those $types remains unresolved.