### PR TITLE
Allow microseconds in date format

### DIFF
--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -98,11 +98,11 @@ class Converter
                         }
                         if (is_numeric($value) && (int)$value == $value) {
                             $time = $value;
+                            $value = new \DateTime();
+                            $value->setTimestamp($time);
                         } else {
-                            $time = strtotime($value);
+                            $value = new \DateTime($value);
                         }
-                        $value = new \DateTime();
-                        $value->setTimestamp($time);
                         break;
                     case Object::NAME:
                     case Nested::NAME:


### PR DESCRIPTION
If the source string includes microseconds, e.g. '2017-10-10T06:59:02.494583Z', these microseconds are thrown away because of strtotime() conversion.