### PR TITLE
results converter continue fix

### DIFF
--- a/Result/Converter.php
+++ b/Result/Converter.php
@@ -94,7 +94,7 @@ class Converter
                 switch ($aliases[$name]['type']) {
                     case 'date':
                         if (is_null($value) || (is_object($value) && $value instanceof \DateTimeInterface)) {
-                            continue;
+                            continue 2;
                         }
                         if (is_numeric($value) && (int)$value == $value) {
                             $time = $value;


### PR DESCRIPTION
In method assignArrayToObject should be continue 2, otherwise it will end the iteration of the rest values.