### PR TITLE
Fix usage of fields as reference

### DIFF
--- a/Mapping/DocumentParser.php
+++ b/Mapping/DocumentParser.php
@@ -111,7 +111,7 @@ class DocumentParser
             }
 
             $fields = [];
-            $aliases = $this->getAliases($class, $fields)
+            $aliases = $this->getAliases($class, $fields);
 
             $this->documents[$className] = [
                 'type' => $document->type ?: Caser::snake($class->getShortName()),

--- a/Mapping/DocumentParser.php
+++ b/Mapping/DocumentParser.php
@@ -111,6 +111,7 @@ class DocumentParser
             }
 
             $fields = [];
+            $aliases = $this->getAliases($class, $fields)
 
             $this->documents[$className] = [
                 'type' => $document->type ?: Caser::snake($class->getShortName()),
@@ -121,7 +122,7 @@ class DocumentParser
                         $fields
                     )
                 ),
-                'aliases' => $this->getAliases($class, $fields),
+                'aliases' => $aliases,
                 'analyzers' => $this->getAnalyzers($class),
                 'objects' => $this->getObjects(),
                 'namespace' => $class->getName(),


### PR DESCRIPTION
90c505a introduced a bug where aliases were not merged in fields.
The problem here is that the second parameter of getAliases is submitted by reference with the intention of using it in fields.
I do recommend solving this a bit different because using parameters by reference is often a bad idea and can lead to problems like this one.

However this reverts the error introduced in 90c505a and fixes #772