### PR TITLE
fixed twig template references for symfony 3.4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,6 +1,5 @@
 parameters:
     es.logging.path: "%kernel.logs_dir%/elasticsearch_%kernel.environment%.log"
-    es.profiler.template: ONGRElasticsearchBundle:Profiler:profiler.html.twig
 
 services:
     es.export:
@@ -52,7 +51,7 @@ services:
             - [setManagers, ["%es.managers%"]]
             - [addLogger, ["@es.tracer"]]
         tags:
-            - {name: data_collector, template: "%es.profiler.template%", id: ongr.profiler}
+            - {name: data_collector, template: "@ONGRElasticsearch/Profiler/profiler.html.twig", id: ongr.profiler}
 
     es.result_converter:
         class: ONGR\ElasticsearchBundle\Result\Converter

--- a/Resources/views/Profiler/profiler.html.twig
+++ b/Resources/views/Profiler/profiler.html.twig
@@ -1,4 +1,4 @@
-{% extends app.request.isXmlHttpRequest ? 'WebProfilerBundle:Profiler:ajax_layout.html.twig' : 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends app.request.isXmlHttpRequest ? '@WebProfiler/Profiler/ajax_layout.html.twig' : '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon -%}
@@ -24,7 +24,7 @@
         <span class="sf-toolbar-status">{{ collector.time }} ms</span>
     </div>
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}
 
 {% block menu %}
@@ -120,7 +120,7 @@
     {{ block('queries') }}
     <h2>Managers</h2>
     {% if collector.managers %}
-        {% include 'WebProfilerBundle:Profiler:table.html.twig' with {data: collector.managers} only %}
+        {% include '@WebProfiler/Profiler/table.html.twig' with {data: collector.managers} only %}
     {% else %}
         <p>
             <em>No managers.</em>


### PR DESCRIPTION
When I try to install the ElasticsearchBundle with symfony 3.4 I get an profiler error on the bottom of the site, stating "An error occurred while loading the web debug toolbar. Open the web profiler.". Opening the web profiler reveals an error: "The profiler template "ONGRElasticsearchBundle:Profiler:profiler.html.twig" for data collector "ongr.profiler" does not exist."

I found two files, where the references to twig templates crashes as of symfony 3.4, due to the new Twig namespace and changed the code:
* Resources/config/services.yml
* Resources/views/Profiler/profiler.html.twig
These have to be changed, in order to work with symfony 3.4 and above (https://symfony.com/doc/3.4/templating.html#referencing-templates-in-a-bundle).

I tested this code with symfony 3.1 & 3.4.