### PR TITLE
Add dependency on symfony/stopwatch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "php": ">=5.6",
         "symfony/framework-bundle": "^2.8|^3.0",
         "symfony/console": "^2.8|^3.0",
+        "symfony/stopwatch": "^2.8|^3.0",
         "symfony/templating": "^2.8|^3.0",
         "doctrine/annotations": "~1.2",
         "doctrine/inflector": "~1.0",


### PR DESCRIPTION
Since it has been dropped by symfony/framework-bundle
@see https://github.com/symfony/framework-bundle/commit/23e2ef12229cf75462b7340acfec88385bb979d9