### PR TITLE
Added normalizer support

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -60,7 +60,7 @@ class Configuration implements ConfigurationInterface
         $node = $builder->root('analysis');
 
         $node
-            ->info('Defines analyzers, tokenizers and filters')
+            ->info('Defines analyzers, normalizers, tokenizers and filters')
             ->addDefaultsIfNotSet()
             ->children()
                 ->arrayNode('tokenizer')
@@ -72,6 +72,10 @@ class Configuration implements ConfigurationInterface
                     ->prototype('variable')->end()
                 ->end()
                 ->arrayNode('analyzer')
+                    ->defaultValue([])
+                    ->prototype('variable')->end()
+                ->end()
+                ->arrayNode('normalizer')
                     ->defaultValue([])
                     ->prototype('variable')->end()
                 ->end()

--- a/Mapping/MetadataCollector.php
+++ b/Mapping/MetadataCollector.php
@@ -251,6 +251,7 @@ class MetadataCollector
             'filter' => [],
             'tokenizer' => [],
             'char_filter' => [],
+            'normalizer' => [],
         ];
 
         /** @var array $mappings All mapping info */
@@ -281,6 +282,10 @@ class MetadataCollector
                     );
                 }
             }
+        }
+
+        if (isset($analysisConfig['normalizer'])) {
+            $typesAnalysis['normalizer'] = $analysisConfig['normalizer'];
         }
 
         $this->enableCache && $this->cache->save($cacheName, $typesAnalysis);


### PR DESCRIPTION
# Rationale

Currently, it is not possible to use [`normalizer`](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/normalizer.html) property for `keyword` fields.

The proposed changes allow the user to set `normalizer` property for a `keyword` field as follows.

# Usage

## Property Declaration

```
/**
 * @ES\Property(
 *     type="text",
 *     options={
 *         "fields"={
 *              "raw"={"type"="keyword"},
 *              "lowercase"={"type"="keyword", "normalizer"="lowercase"}
 *         }
 *     }
 * )
 */
private $property;
```

## Configuration

```yaml
ongr_elasticsearch:
    analysis:
        normalizer:
            lowercase:
                type: custom
                filter:
                    - lowercase

```
