### PR TITLE
Restrict compatible PHP versions to currently supported ones

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=5.6,<7.3",
         "symfony/framework-bundle": "^2.8|^3.0|^4",
         "symfony/console": "^2.8|^3.0|^4",
         "symfony/stopwatch": "^2.8|^3.0|^4",


### PR DESCRIPTION
We haven't tested PHP 7.3, 7.4, 8.0 or 9.0 yet, so we shouldn't claim compatibility with *every* version greater than or equal to PHP 5.6.