### PR TITLE
Events::PRE_PERSIST work with object before bulk

### DIFF
--- a/Event/Events.php
+++ b/Event/Events.php
@@ -17,6 +17,11 @@ namespace ONGR\ElasticsearchBundle\Event;
 final class Events
 {
     /**
+     * The PRE_PERSIST event occurs before convert to Array
+     */
+    const PRE_PERSIST = 'es.pre_persist';
+
+    /**
      * The BULK event occurs before during the processing of bulk method
      */
     const BULK = 'es.bulk';

--- a/Event/PrePersistEvent.php
+++ b/Event/PrePersistEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class PrePersistEvent extends Event
+{
+    /**
+     * @var object
+     */
+    private $document;
+
+    /**
+     * PrePersistEvent constructor.
+     * @param $document
+     */
+    public function __construct($document)
+    {
+        $this->document = $document;
+    }
+
+    /**
+     * @return object
+     */
+    public function getDocument()
+    {
+        return $this->document;
+    }
+
+    /**
+     * @param object $document
+     */
+    public function setDocument($document)
+    {
+        $this->document = $document;
+    }
+}

--- a/Service/Manager.php
+++ b/Service/Manager.php
@@ -16,6 +16,7 @@ use Elasticsearch\Common\Exceptions\Missing404Exception;
 use ONGR\ElasticsearchBundle\Event\Events;
 use ONGR\ElasticsearchBundle\Event\BulkEvent;
 use ONGR\ElasticsearchBundle\Event\CommitEvent;
+use ONGR\ElasticsearchBundle\Event\PrePersistEvent;
 use ONGR\ElasticsearchBundle\Exception\BulkWithErrorsException;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use ONGR\ElasticsearchBundle\Result\Converter;
@@ -330,6 +331,11 @@ class Manager
      */
     public function persist($document)
     {
+        $this->eventDispatcher->dispatch(
+            Events::PRE_PERSIST,
+            new PrePersistEvent($document)
+        );
+
         $documentArray = $this->converter->convertToArray($document);
         $type = $this->getMetadataCollector()->getDocumentType(get_class($document));
 

--- a/Tests/Unit/Event/PrePersistEventTest.php
+++ b/Tests/Unit/Event/PrePersistEventTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Tests\Unit\Event;
+
+use ONGR\ElasticsearchBundle\Event\PrePersistEvent;
+use ONGR\ElasticsearchBundle\Tests\app\fixture\TestBundle\Document\Product;
+
+class PrePersistEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetters()
+    {
+        $entity = new Product();
+        $event = new PrePersistEvent($entity);
+
+        $this->assertInstanceOf(Product::class, $event->getDocument());
+    }
+}


### PR DESCRIPTION
Required to work with the object to set the creation time (for example)