### PR TITLE
Fix for memory problem in export index

### DIFF
--- a/Service/ExportService.php
+++ b/Service/ExportService.php
@@ -82,7 +82,6 @@ class ExportService
         $filename = str_replace('.json', '', $filename);
         $writer = $this->getWriter($this->getFilePath($filename.'.json'), $metadata);
 
-        $file = [];
         foreach ($results as $data) {
             if ($counter >= $maxLinesInFile) {
                 $writer->finalize();
@@ -99,7 +98,6 @@ class ExportService
 
             $doc = array_intersect_key($data, array_flip(['_id', '_type', '_source']));
             $writer->push($doc);
-            $file[] = $doc;
             $progress->advance();
             $counter++;
         }


### PR DESCRIPTION
As file value was used to store all of the documents it stopped the script when the value was getting too big due to number of documents stored in it. Value was not used so I just removed it.