### PR TITLE
Configuration to allow request_options to be used

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -117,6 +117,11 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')
                                 ->end()
                             ->end()
+                            ->arrayNode('client_options')
+                                ->defaultValue([])
+                                ->info('Sets client params for connection.')
+                                ->prototype('variable')->end()
+                            ->end()
                             ->arrayNode('settings')
                                 ->defaultValue(
                                     [

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -22,7 +22,7 @@ ongr_elasticsearch:
               max_gram: 20
     managers:
         default:
-            index: 
+            index:
                 hosts:
                     - 127.0.0.1:9200
                 index_name: ongr-default
@@ -33,8 +33,13 @@ ongr_elasticsearch:
             logger: true #default %kernel.debug%
             mappings:
                 - AcmeBarBundle #Scans all bundle documents
+            client_options: # http://docs.guzzlephp.org/en/stable/request-options.html
+                allow_redirects: false
+                connect_timeout: 5
+                timeout: 20
+
         custom:
-            index: 
+            index:
                 hosts:
                     - 10.0.0.1:9200 #default 127.0.0.1:9200
                 index_name: ongr-custom

--- a/Service/ManagerFactory.php
+++ b/Service/ManagerFactory.php
@@ -102,6 +102,7 @@ class ManagerFactory
 
         $client = ClientBuilder::create();
         $client->setHosts($connection['hosts']);
+        $client->setConnectionParams(['client' => $connection['client_options']]);
         $client->setTracer($this->tracer);
 
         if ($this->logger && $managerConfig['logger']['enabled']) {


### PR DESCRIPTION
I have found that I need to set some of the client request options for
the transport layer within the Connection via the Manager.

This change allows for any of the GuzzleHttp Client Request Options to
be set in yaml per index and used within the elastic search libraries.

- Carl.