### PR TITLE
Make mappings configuration unique to allow prepend  of configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: php
 php:
   - 5.6

--- a/DependencyInjection/ONGRElasticsearchExtension.php
+++ b/DependencyInjection/ONGRElasticsearchExtension.php
@@ -46,9 +46,15 @@ class ONGRElasticsearchExtension extends Extension
         $config['profiler'] = isset($config['profiler']) ?
             $config['profiler'] : $container->getParameter('kernel.debug');
 
+        
+        $managers = $config['managers'];
+        foreach ($managers as &$manager) {
+            $manager['mappings'] = array_unique($manager['mappings']);
+        }
+        
         $container->setParameter('es.cache', $config['cache']);
         $container->setParameter('es.analysis', $config['analysis']);
-        $container->setParameter('es.managers', $config['managers']);
+        $container->setParameter('es.managers', $managers);
         $definition = new Definition(
             'ONGR\ElasticsearchBundle\Service\ManagerFactory',
             [


### PR DESCRIPTION
Sometimes you want to prepend a configuration in a bundle if then the developer of the bundle defines the same bundle the ongr elasticsearch bundle should not crash and just import it once. 