### PR TITLE
do not set _index in bulk data

### DIFF
--- a/Service/IndexService.php
+++ b/Service/IndexService.php
@@ -397,7 +397,6 @@ class IndexService
     public function bulk(string $operation, array $data = [], $autoCommit = true): array
     {
         $bulkParams = [
-            '_index' => $this->getIndexName(),
             '_type' => $this->getTypeName(),
             '_id' => $data['_id'] ?? null,
         ];


### PR DESCRIPTION
in order to prevent error "explicit index in bulk is not allowed"
in ES instances where rest.action.multi.allow_explicit_index is set to false.

We don't need this _index setting in `bulk` method because in `commit`
method index is set to $this->getIndexName()