### PR TITLE
guess getters with underscore-to-camelcase conversion

### DIFF
--- a/Mapping/DocumentParser.php
+++ b/Mapping/DocumentParser.php
@@ -289,6 +289,17 @@ class DocumentParser
             return 'is' . ucfirst($name);
         }
 
+        // if there are underscores in the name convert them to CamelCase
+        if (strpos($name, '_')) {
+            $name = Caser::camel($name);
+            if ($class->hasMethod('get' . ucfirst($name))) {
+                return 'get' . $name;
+            }
+            if ($class->hasMethod('is' . ucfirst($name))) {
+                return 'is' . $name;
+            }
+        }
+
         throw new \Exception("Could not determine a getter for `$name` of class `{$class->getNamespaceName()}`");
     }
 
@@ -296,6 +307,14 @@ class DocumentParser
     {
         if ($class->hasMethod('set' . ucfirst($name))) {
             return 'set' . ucfirst($name);
+        }
+
+        // if there are underscores in the name convert them to CamelCase
+        if (strpos($name, '_')) {
+            $name = Caser::camel($name);
+            if ($class->hasMethod('set' . ucfirst($name))) {
+                return 'set' . $name;
+            }
         }
 
         throw new \Exception("Could not determine a setter for `$name` of class `{$class->getNamespaceName()}`");


### PR DESCRIPTION
e.g. find method `getSomeProperty()` for property `some_property`