### PR TITLE
Fix "fields" annotation

### DIFF
--- a/Mapping/DocumentParser.php
+++ b/Mapping/DocumentParser.php
@@ -265,7 +265,14 @@ class DocumentParser
             }
         }
 
-        foreach (['tokenizer', 'filter', 'normalizer', 'char_filter'] as $type) {
+        $normalizers = $this->getListFromArrayByKey('normalizer', $mapping);
+        foreach ($normalizers as $normalizer) {
+            if (isset($this->analysisConfig['normalizer'][$normalizer])) {
+                $config['normalizer'][$normalizer] = $this->analysisConfig['normalizer'][$normalizer];
+            }
+        }
+
+        foreach (['tokenizer', 'filter', 'char_filter'] as $type) {
             $list = $this->getListFromArrayByKey($type, $config);
 
             foreach ($list as $listItem) {

--- a/Mapping/DocumentParser.php
+++ b/Mapping/DocumentParser.php
@@ -151,6 +151,9 @@ class DocumentParser
 
                 if ($annotation instanceof Property) {
                     $fieldMapping['type'] = $annotation->type;
+                    if ($annotation->fields) {
+                        $fieldMapping['fields'] = $annotation->fields;
+                    }
                     $fieldMapping['analyzer'] = $annotation->analyzer;
                     $fieldMapping['search_analyzer'] = $annotation->searchAnalyzer;
                     $fieldMapping['search_quote_analyzer'] = $annotation->searchQuoteAnalyzer;

--- a/Tests/app/src/Document/DummyDocument.php
+++ b/Tests/app/src/Document/DummyDocument.php
@@ -39,11 +39,9 @@ class DummyDocument
      * @ES\Property(
      *  type="text",
      *  name="title",
-     *  settings={
-     *    "fields"={
-     *        "raw"={"type"="keyword"},
-     *        "increment"={"type"="text", "analyzer"="incrementalAnalyzer"}
-     *    }
+     *  fields={
+     *    "raw"={"type"="keyword"},
+     *    "increment"={"type"="text", "analyzer"="incrementalAnalyzer"}
      *  }
      * )
      */

--- a/Tests/app/src/Document/TestDocument.php
+++ b/Tests/app/src/Document/TestDocument.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\App\Document;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use ONGR\ElasticsearchBundle\Annotation as ES;
+
+/**
+ * test document for unit testing of DocumentParser class
+ *
+ * @ES\Index(alias="testdocument")
+ */
+class TestDocument
+{
+    // This con't is only as a helper.
+    CONST INDEX_NAME = 'testdocument';
+
+    /**
+     * @ES\Id()
+     */
+    public $id;
+
+    /**
+     * @ES\Property(
+     *  type="text",
+     *  name="title",
+     *  fields={
+     *    "raw"={"type"="keyword"},
+     *    "increment"={"type"="text", "analyzer"="incrementalAnalyzer"},
+     *    "sorting"={"type"="keyword", "normalizer"="lowercase_normalizer"}
+     *  }
+     * )
+     */
+    public $title;
+}


### PR DESCRIPTION
The `fields` property inside the `Property` annotation did not work. Though the `Property` class already had the `fields` member this was unused and one had to write the `fields` mapping inside the `settings` array. Now the following annotation works correctly:

```
    /**
     * @ES\Property(
     *  type="text",
     *  fields={
     *    "raw"={"type"="keyword"},
     *    "increment"={"type"="text", "analyzer"="incrementalAnalyzer"}
     *  }
     * )
     */
```