### PR TITLE
do not remove fields with falsy values while persisting

### DIFF
--- a/Service/IndexService.php
+++ b/Service/IndexService.php
@@ -432,7 +432,10 @@ class IndexService
      */
     public function persist($document): void
     {
-        $documentArray = array_filter($this->converter->convertDocumentToArray($document));
+        $documentArray = array_filter($this->converter->convertDocumentToArray($document), function($val) {
+            // remove unset properties but keep other falsy values
+            return !($val === null);
+        });
 
         $this->bulk('index', $documentArray);
     }

--- a/Service/IndexService.php
+++ b/Service/IndexService.php
@@ -432,7 +432,7 @@ class IndexService
      */
     public function persist($document): void
     {
-        $documentArray = array_filter($this->converter->convertDocumentToArray($document), function($val) {
+        $documentArray = array_filter($this->converter->convertDocumentToArray($document), function ($val) {
             // remove unset properties but keep other falsy values
             return !($val === null);
         });


### PR DESCRIPTION
Fixes #891 for me.

But maybe it would be even better to remove the `array_filter` call completely from the `persist` method and remove the unset properties in the `Converter::convertDocumentToArray` method.