### PR TITLE
Fix index configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -68,6 +68,7 @@ class Configuration implements ConfigurationInterface
 
             ->arrayNode('indexes')
                 ->defaultValue([])
+                ->useAttributeAsKey('namespace')
                 ->info(
                     'In case you want to override index settings defined in the annotation.' .
                     ' e.g. use env variables instead.'


### PR DESCRIPTION
Added `useAttributeAsKey` config option to the indexes configuration array. Without this option, the configuration array was not built correctly when multiple indexes are given: Only in the first entry the index name was used as key but for the following entries numeric indices where used and so the config was not found in IndexService. This commit fixes this problem.