### PR TITLE
Set date field value to NULL from previous FALSE

### DIFF
--- a/Mapping/Converter.php
+++ b/Mapping/Converter.php
@@ -93,7 +93,7 @@ class Converter
                 }
             } else {
                 if ($fieldMeta['type'] == 'date') {
-                    $value = \DateTime::createFromFormat(\DateTime::ISO8601, $value);
+                    $value = \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value) ?: null;
                 }
                 if ($fieldMeta['public']) {
                     $object->{$fieldMeta['name']} = $value;

--- a/Mapping/Converter.php
+++ b/Mapping/Converter.php
@@ -93,7 +93,7 @@ class Converter
                 }
             } else {
                 if ($fieldMeta['type'] == 'date') {
-                    $value = \DateTime::createFromFormat(\DateTimeInterface::ISO8601, $value) ?: null;
+                    $value = \DateTime::createFromFormat(\DateTime::ISO8601, $value) ?: null;
                 }
                 if ($fieldMeta['public']) {
                     $object->{$fieldMeta['name']} = $value;


### PR DESCRIPTION
In `Converter::denormalize()`, when the serialized value of a date field is empty or the date parsing fails for another reason, `\DateTime::createFromFormat()` returns FALSE. This FALSE value must be converted to NULL in order to pass it to a setter with a `?\DateTimeInterface` type hint.