### PR TITLE
Remove dependency from symfony/templating (closes #904)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "symfony/dependency-injection": "^3.4|^4.1",
         "symfony/console": "^3.4|^4.1",
         "symfony/stopwatch": "^3.4|^4.1",
-        "symfony/templating": "^3.4|^4.1",
         "symfony/finder": "^3.4|^4.1",
         "symfony/serializer": "^3.4|^4.1",
         "symfony/cache": "^3.4|^4.1",


### PR DESCRIPTION
Closes #904

If I am not mistaken, no code changes needed because #829 provided correct references to the templates