### PR TITLE
Add support for es7 in version 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,37 @@
 sudo: false
 language: php
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
+
+matrix:
+  include:
+    - language: php
+      php: 5.6
+      env:
+        - SYMFONY=^3.4
+
+    - language: php
+      php: 7.0
+      env:
+        - OCRAMIUS_PACKAGE_VERSION=true
+        - SYMFONY=^3.4
+
+    - language: php
+      php: 7.2
+      env:
+        - OCRAMIUS_PACKAGE_VERSION=true
+        - SYMFONY=^3.4
+
+    - language: php
+      php: 7.3
+      env:
+        - OCRAMIUS_PACKAGE_VERSION=true
+        - SYMFONY=^4.4
+
+    - language: php
+      php: 7.4
+      env:
+        - OCRAMIUS_PACKAGE_VERSION=true
+        - SYMFONY=^4.4
+
 env:
   global:
     - ES_VERSION=5.6.8 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
@@ -16,7 +42,8 @@ install:
 before_script:
   - echo 'memory_limit=-1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer require --no-update symfony/symfony:${SYMFONY}
-  - composer config -g github-oauth.github.com $GITHUB_COMPOSER_AUTH
+  - if [[ $OCRAMIUS_PACKAGE_VERSION = "true" ]]; then composer require ocramius/package-versions:^1.0 --no-update ;fi
+  - if [[ $TRAVIS_SECURE_ENV_VARS = "true" ]]; then composer config -g github-oauth.github.com $GITHUB_COMPOSER_AUTH; fi
   - composer install --no-interaction --prefer-dist
 
 script:

--- a/Service/ExportService.php
+++ b/Service/ExportService.php
@@ -116,7 +116,7 @@ class ExportService
      */
     protected function getFilePath($filename)
     {
-        if ($filename{0} == '/' || strstr($filename, ':') !== false) {
+        if ($filename[0] == '/' || strstr($filename, ':') !== false) {
             return $filename;
         }
 

--- a/Service/ImportService.php
+++ b/Service/ImportService.php
@@ -73,7 +73,7 @@ class ImportService
      */
     protected function getFilePath($filename)
     {
-        if ($filename{0} == '/' || strstr($filename, ':') !== false) {
+        if ($filename[0] == '/' || strstr($filename, ':') !== false) {
             return $filename;
         }
 

--- a/Service/ManagerFactory.php
+++ b/Service/ManagerFactory.php
@@ -17,6 +17,7 @@ use ONGR\ElasticsearchBundle\Event\PostCreateManagerEvent;
 use ONGR\ElasticsearchBundle\Event\PreCreateManagerEvent;
 use ONGR\ElasticsearchBundle\Mapping\MetadataCollector;
 use ONGR\ElasticsearchBundle\Result\Converter;
+use PackageVersions\Versions;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -123,6 +124,16 @@ class ManagerFactory
                 ]
             ),
         ];
+
+        if (class_exists(Versions::class)) {
+            $elasticSearchVersion = explode('@', Versions::getVersion('ongr/elasticsearch-dsl'))[0];
+            if (0 === strpos($elasticSearchVersion, 'v')) {
+                $elasticSearchVersion = substr($elasticSearchVersion, 1);
+            }
+            if (version_compare($elasticSearchVersion, '7.0.0', '>=')) {
+                $indexSettings['include_type_name'] = true;
+            }
+        }
 
         $this->eventDispatcher &&
             $this->eventDispatcher->dispatch(

--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         "doctrine/cache": "~1.4",
         "doctrine/collections": "~1.4",
         "monolog/monolog": "~1.10",
-        "ongr/elasticsearch-dsl": "~5.0|~6.0"
+        "ongr/elasticsearch-dsl": "~5.0|~6.0|~7.0"
     },
     "require-dev": {
-        "elasticsearch/elasticsearch": "~5.0|~6.0",
+        "elasticsearch/elasticsearch": "~5.0|~6.0|~7.0",
         "mikey179/vfsstream": "~1.4",
         "phpunit/phpunit": "~5.6",
         "squizlabs/php_codesniffer": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6,<7.4",
+        "php": "^5.6|^7.0",
         "symfony/framework-bundle": "^2.8|^3.0|^4",
         "symfony/console": "^2.8|^3.0|^4",
         "symfony/stopwatch": "^2.8|^3.0|^4",


### PR DESCRIPTION
This change would allow to install the ES7 client and use it with the same api. It would help us that the community can use the newest ES version when using the SuluArticleBundle. Upgrading to the newest version of the bundle would be in our case to many bc breaks at current state.

The change itself is simple if its uses *Elasticsearch 7* the Index settings is set to:

```http
include_type_name=true
```