### PR TITLE
Set tracer only when available

### DIFF
--- a/Service/ManagerFactory.php
+++ b/Service/ManagerFactory.php
@@ -102,7 +102,10 @@ class ManagerFactory
 
         $client = ClientBuilder::create();
         $client->setHosts($connection['hosts']);
-        $client->setTracer($this->tracer);
+
+        if ($this->tracer) {
+            $client->setTracer($this->tracer);
+        }
 
         if ($this->logger && $managerConfig['logger']['enabled']) {
             $client->setLogger($this->logger);


### PR DESCRIPTION
The `setTracer` should only be called when `$this->tracer` is not null else it will throw a exception:

https://github.com/elastic/elasticsearch-php/blob/e81fe04810fbbc24191408eecc1d6f74c2ac8250/src/Elasticsearch/ClientBuilder.php#L313-L315