### PR TITLE
Fix autowiring

### DIFF
--- a/Command/AbstractIndexServiceAwareCommand.php
+++ b/Command/AbstractIndexServiceAwareCommand.php
@@ -13,10 +13,10 @@ namespace ONGR\ElasticsearchBundle\Command;
 
 use ONGR\ElasticsearchBundle\DependencyInjection\Configuration;
 use ONGR\ElasticsearchBundle\Service\IndexService;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 abstract class AbstractIndexServiceAwareCommand extends Command
 {
@@ -24,7 +24,7 @@ abstract class AbstractIndexServiceAwareCommand extends Command
 
     const INDEX_OPTION = 'index';
 
-    public function __construct(Container $container)
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
         parent::__construct();
@@ -58,7 +58,7 @@ abstract class AbstractIndexServiceAwareCommand extends Command
         );
     }
 
-    public function getContainer(): Container
+    public function getContainer(): ContainerInterface
     {
         return $this->container;
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,9 @@ parameters:
 
 services:
 
-    _defaults: { public: true }
+    _defaults:
+        public: true
+        autowire: true
 
     ONGR\ElasticsearchBundle\Command\:
         resource: '../../Command'


### PR DESCRIPTION
Autowiring doesn't work for me without `autowire: true` in `services.yml` and using the `Container` as typehint doesn result in the following message:
> Cannot autowire service "ONGR\ElasticsearchBundle\Command\CacheClearCommand": argument "$container" of method "ONGR\ElasticsearchBundle\Command\AbstractIndexServiceAwareCommand::__construct()" references class "Symfony\Component\DependencyInject  
  ion\Container" but no such service exists. Try changing the type-hint to one of its parents: interface "Psr\Container\ContainerInterface", or interface "Symfony\Component\DependencyInjection\ContainerInterface".