### PR TITLE
Remove filtering of empty _raw values

### DIFF
--- a/Result/DocumentIterator.php
+++ b/Result/DocumentIterator.php
@@ -41,6 +41,6 @@ class DocumentIterator extends AbstractResultsIterator
         $data = $raw['_source'] ?? $raw['_fields'] ?? null;
         $data['_id'] = $raw['_id'] ?? null;
 
-        return $this->getConverter()->convertArrayToDocument($this->getIndex()->getNamespace(), array_filter($data));
+        return $this->getConverter()->convertArrayToDocument($this->getIndex()->getNamespace(), $data);
     }
 }


### PR DESCRIPTION
Why are we removing all values here which are `null`, `0` or `false`?
I've seen a solution where only `null` is removed which should at least apply here:
```
        return $this->getConverter()->convertArrayToDocument($this->getIndex()->getNamespace(), array_filter($data, function ($val) {
            // remove unset properties but keep other falsy values
            return !($val === null);
        }));
```

But there is the `find` method in the `IndexService` which doesn't do it either: https://github.com/ongr-io/ElasticsearchBundle/blob/master/Service/IndexService.php#L197

@saimaz Any idea why filtering there should be needed? Null values seem perfectly fine for me (If the getter allows `null` and null values are written to ES, we can certainly allow to require nullable typehints in the setters).