### PR TITLE
[POC] Implented working config with multiple indexes per document class

### DIFF
--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -92,10 +92,11 @@ class MappingPass implements CompilerPassInterface
         foreach (array_diff($indexClasses, $overwrittenClasses) as $indexClass) {
             try {
                 $indexSettingsArray[$indexClass] = $this->parseIndexSettingsFromClass($parser, $indexClass);
-            } catch (DocumentIndexParserException $e) {}
+            } catch (DocumentIndexParserException $e) {
+            }
         }
 
-        foreach($indexSettingsArray as $indexSettings) {
+        foreach ($indexSettingsArray as $indexSettings) {
             $this->createIndex($container, $indexSettings);
         }
 
@@ -135,7 +136,8 @@ class MappingPass implements CompilerPassInterface
         return $indexSettings;
     }
 
-    private function createIndex(Container $container, IndexSettings $indexSettings) {
+    private function createIndex(Container $container, IndexSettings $indexSettings)
+    {
         $converterDefinition = $container->getDefinition(Converter::class);
 
         $indexSettingsDefinition = new Definition(

--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -13,11 +13,13 @@ namespace ONGR\ElasticsearchBundle\DependencyInjection\Compiler;
 
 use ONGR\ElasticsearchBundle\Annotation\Index;
 use ONGR\ElasticsearchBundle\DependencyInjection\Configuration;
+use ONGR\ElasticsearchBundle\Exception\DocumentIndexParserException;
 use ONGR\ElasticsearchBundle\Mapping\Converter;
 use ONGR\ElasticsearchBundle\Mapping\DocumentParser;
 use ONGR\ElasticsearchBundle\Mapping\IndexSettings;
 use ONGR\ElasticsearchBundle\Service\IndexService;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -36,9 +38,65 @@ class MappingPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $kernelDir = $container->getParameter('kernel.project_dir');
+        $parser = $container->get(DocumentParser::class);
 
+        $indexClasses = [];
+        $indexSettingsArray = [];
         foreach ($container->getParameter(Configuration::ONGR_SOURCE_DIR) as $dir) {
-            $this->handleDirectoryMapping($container, $kernelDir . $dir);
+            foreach ($this->getNamespaces($kernelDir . $dir) as $namespace) {
+                $indexClasses[$namespace] = $namespace;
+            }
+        }
+
+        $overwrittenClasses = [];
+        $indexOverrides = $container->getParameter(Configuration::ONGR_INDEXES_OVERRIDE);
+
+        foreach ($indexOverrides as $name => $indexOverride) {
+            $class = isset($indexOverride['class']) ? $indexOverride['class'] : $name;
+
+            if (!isset($indexClasses[$class])) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Document `%s` defined in ongr_elasticsearch.indexes config could not been found',
+                        $class,
+                    )
+                );
+            }
+
+            $indexSettings = $this->parseIndexSettingsFromClass($parser, $class);
+
+            if ($class !== $name) {
+                $indexSettings->setIndexName('ongr.es.index.'.$name);
+            }
+
+            if (isset($indexOverride['alias'])) {
+                $indexSettings->setAlias($indexOverride['alias']);
+            }
+
+            if (isset($indexOverride['settings'])) {
+                $indexSettings->setIndexMetadata($indexOverride['settings']);
+            }
+
+            if (isset($indexOverride['hosts'])) {
+                $indexSettings->setHosts($indexOverride['hosts']);
+            }
+
+            if (isset($indexOverride['default'])) {
+                $indexSettings->setDefaultIndex($indexOverride['default']);
+            }
+
+            $indexSettingsArray[$name] = $indexSettings;
+            $overwrittenClasses[$class] = $class;
+        }
+
+        foreach (array_diff($indexClasses, $overwrittenClasses) as $indexClass) {
+            try {
+                $indexSettingsArray[$indexClass] = $this->parseIndexSettingsFromClass($parser, $indexClass);
+            } catch (DocumentIndexParserException $e) {}
+        }
+
+        foreach($indexSettingsArray as $indexSettings) {
+            $this->createIndex($container, $indexSettings);
         }
 
         $container->setParameter(Configuration::ONGR_INDEXES, $this->indexes);
@@ -48,88 +106,84 @@ class MappingPass implements CompilerPassInterface
         );
     }
 
-    /**
-     * @param ContainerBuilder $container
-     * @param string $dir
-     *
-     * @throws \ReflectionException
-     */
-    private function handleDirectoryMapping(ContainerBuilder $container, string $dir): void
+    private function parseIndexSettingsFromClass(DocumentParser $parser, string $className) : IndexSettings
     {
-        /** @var DocumentParser $parser */
-        $parser = $container->get(DocumentParser::class);
-        $indexesOverride = $container->getParameter(Configuration::ONGR_INDEXES_OVERRIDE);
+        $class = new \ReflectionClass($className);
+
+        /** @var Index $document */
+        $document = $parser->getIndexAnnotation($class);
+
+        if ($document === null) {
+            throw new DocumentIndexParserException();
+        }
+
+        $indexSettings = new IndexSettings(
+            $className,
+            $className,
+            $parser->getIndexAliasName($class),
+            $parser->getIndexMetadata($class),
+            $parser->getPropertyMetadata($class),
+            $document->hosts,
+            $parser->isDefaultIndex($class)
+        );
+
+        $indexSettings->setIndexMetadata(['settings' => [
+            'number_of_replicas' => $document->numberOfReplicas,
+            'number_of_shards' => $document->numberOfShards,
+        ]]);
+
+        return $indexSettings;
+    }
+
+    private function createIndex(Container $container, IndexSettings $indexSettings) {
         $converterDefinition = $container->getDefinition(Converter::class);
 
-        foreach ($this->getNamespaces($dir) as $namespace) {
-            $class = new \ReflectionClass($namespace);
+        $indexSettingsDefinition = new Definition(
+            IndexSettings::class,
+            [
+                $indexSettings->getNamespace(),
+                $indexSettings->getAlias(),
+                $indexSettings->getAlias(),
+                $indexSettings->getIndexMetadata(),
+                $indexSettings->getPropertyMetadata(),
+                $indexSettings->getHosts(),
+                $indexSettings->isDefaultIndex(),
+            ]
+        );
 
-            if (isset($indexesOverride[$namespace]['alias']) && $indexesOverride[$namespace]['alias']) {
-                $indexAlias = $indexesOverride[$namespace]['alias'];
-            } else {
-                $indexAlias = $parser->getIndexAliasName($class);
-            }
+        $indexServiceDefinition = new Definition(IndexService::class, [
+            $indexSettings->getNamespace(),
+            $converterDefinition,
+            $container->getDefinition('event_dispatcher'),
+            $indexSettingsDefinition,
+            $container->getParameter(Configuration::ONGR_PROFILER_CONFIG)
+                ? $container->getDefinition('ongr.esb.tracer') : null
+        ]);
 
-            /** @var Index $document */
-            $document = $parser->getIndexAnnotation($class);
-            $indexMetadata = $parser->getIndexMetadata($class);
+        $indexServiceDefinition->setPublic(true);
+        $converterDefinition->addMethodCall(
+            'addClassMetadata',
+            [
+                $indexSettings->getNamespace(),
+                $indexSettings->getPropertyMetadata()
+            ]
+        );
 
-            if (!empty($indexMetadata)) {
-                $indexMetadata['settings'] = array_filter(array_merge_recursive(
-                    $indexMetadata['settings'] ?? [],
-                    [
-                        'number_of_replicas' => $document->numberOfReplicas,
-                        'number_of_shards' => $document->numberOfShards,
-                    ],
-                    $indexesOverride[$namespace]['settings'] ?? []
-                ));
+        $container->setDefinition($indexSettings->getIndexName(), $indexServiceDefinition);
+        $this->indexes[$indexSettings->getAlias()] = $indexSettings->getIndexName();
+        $isCurrentIndexDefault = $indexSettings->isDefaultIndex();
+        if ($this->defaultIndex && $isCurrentIndexDefault) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Only one index can be set as default. We found 2 indexes as default ones `%s` and `%s`',
+                    $this->defaultIndex,
+                    $indexSettings->getAlias()
+                )
+            );
+        }
 
-                $indexSettings = new Definition(
-                    IndexSettings::class,
-                    [
-                        $namespace,
-                        $indexAlias,
-                        $indexAlias,
-                        $indexMetadata,
-                        $indexesOverride[$namespace]['hosts'] ?? $document->hosts,
-                        $indexesOverride[$namespace]['default'] ?? $document->default,
-                    ]
-                );
-
-                $indexServiceDefinition = new Definition(IndexService::class, [
-                    $namespace,
-                    $converterDefinition,
-                    $container->getDefinition('event_dispatcher'),
-                    $indexSettings,
-                    $container->getParameter(Configuration::ONGR_PROFILER_CONFIG)
-                        ? $container->getDefinition('ongr.esb.tracer') : null
-                ]);
-                $indexServiceDefinition->setPublic(true);
-                $converterDefinition->addMethodCall(
-                    'addClassMetadata',
-                    [
-                        $namespace,
-                        $parser->getPropertyMetadata($class)
-                    ]
-                );
-
-                $container->setDefinition($namespace, $indexServiceDefinition);
-                $this->indexes[$indexAlias] = $namespace;
-                $isCurrentIndexDefault = $parser->isDefaultIndex($class);
-                if ($this->defaultIndex && $isCurrentIndexDefault) {
-                    throw new \RuntimeException(
-                        sprintf(
-                            'Only one index can be set as default. We found 2 indexes as default ones `%s` and `%s`',
-                            $this->defaultIndex,
-                            $indexAlias
-                        )
-                    );
-                }
-
-                if ($isCurrentIndexDefault) {
-                    $this->defaultIndex = $indexAlias;
-                }
-            }
+        if ($isCurrentIndexDefault) {
+            $this->defaultIndex = $indexSettings->getAlias();
         }
     }
 

--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -58,7 +58,7 @@ class MappingPass implements CompilerPassInterface
                 throw new \RuntimeException(
                     sprintf(
                         'Document `%s` defined in ongr_elasticsearch.indexes config could not been found',
-                        $class,
+                        $class
                     )
                 );
             }

--- a/Exception/DocumentIndexParserException.php
+++ b/Exception/DocumentIndexParserException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchBundle\Exception;
+
+class DocumentIndexParserException extends DocumentParserException
+{
+}

--- a/Mapping/IndexSettings.php
+++ b/Mapping/IndexSettings.php
@@ -16,6 +16,7 @@ class IndexSettings
     private $indexName;
     private $alias;
     private $indexMetadata;
+    private $propertyMetadata;
     private $hosts;
     private $defaultIndex = false;
 
@@ -24,6 +25,7 @@ class IndexSettings
         string $indexName,
         string $alias,
         array $indexMetadata = [],
+        array $propertyMetadata = [],
         array $hosts = [],
         bool $defaultIndex = false
     ) {
@@ -31,6 +33,7 @@ class IndexSettings
         $this->indexName = $indexName;
         $this->alias = $alias;
         $this->indexMetadata = $indexMetadata;
+        $this->propertyMetadata = $propertyMetadata;
         $this->hosts = $hosts;
         $this->defaultIndex = $defaultIndex;
     }
@@ -40,10 +43,9 @@ class IndexSettings
         return $this->namespace;
     }
 
-    public function setNamespace($namespace): self
+    public function setNamespace($namespace): void
     {
         $this->namespace = $namespace;
-        return $this;
     }
 
     public function getIndexName()
@@ -51,10 +53,9 @@ class IndexSettings
         return $this->indexName;
     }
 
-    public function setIndexName($indexName): self
+    public function setIndexName($indexName): void
     {
         $this->indexName = $indexName;
-        return $this;
     }
 
     public function getAlias()
@@ -62,10 +63,9 @@ class IndexSettings
         return $this->alias;
     }
 
-    public function setAlias($alias): self
+    public function setAlias($alias): void
     {
         $this->alias = $alias;
-        return $this;
     }
 
     public function getIndexMetadata()
@@ -73,10 +73,22 @@ class IndexSettings
         return $this->indexMetadata;
     }
 
-    public function setIndexMetadata($indexMetadata): self
+    public function setIndexMetadata($indexMetadata): void
     {
-        $this->indexMetadata = $indexMetadata;
-        return $this;
+        $this->indexMetadata = array_filter(array_merge_recursive(
+            $this->indexMetadata,
+            $indexMetadata
+        ));
+    }
+
+    public function getPropertyMetadata(): array
+    {
+        return $this->propertyMetadata;
+    }
+
+    public function setPropertyMetadata(array $propertyMetadata): void
+    {
+        $this->propertyMetadata = $propertyMetadata;
     }
 
     public function getHosts()
@@ -84,10 +96,9 @@ class IndexSettings
         return $this->hosts;
     }
 
-    public function setHosts($hosts): self
+    public function setHosts($hosts): void
     {
         $this->hosts = $hosts;
-        return $this;
     }
 
     public function isDefaultIndex(): bool
@@ -95,9 +106,8 @@ class IndexSettings
         return $this->defaultIndex;
     }
 
-    public function setDefaultIndex(bool $defaultIndex): self
+    public function setDefaultIndex(bool $defaultIndex): void
     {
         $this->defaultIndex = $defaultIndex;
-        return $this;
     }
 }


### PR DESCRIPTION
I've made a proof of concept for a solution where we can have multiple indexes for one document class again (https://github.com/ongr-io/ElasticsearchBundle/issues/902). The config can look like this:
```
ongr_elasticsearch:
    indexes:
        package_de_chf:
            class: App\Document\Package
            alias: package_de_chf
            hosts:
                - '%env(ELASTICSEARCH_ENDPOINT)%'
        package_fr_chf:
            class: App\Document\Package
            alias: package_fr_chf
            hosts:
                - '%env(ELASTICSEARCH_ENDPOINT)%'
        App\Document\PackageIsochrone:
            hosts:
                - '%env(ELASTICSEARCH_ENDPOINT)%'
```

If a `class` parameter is provided the `indexes` children keys can be a self defined string which will be used as the index service name (if `package_de_chf` is used, the service will be called `ongr.es.index.package_de_chf`).

I abused the `IndexSettings` class to create a temporary storage before creating the definition. I am not sure if this is a good solution or if we should just work with a separate class (only difference would be the `propertyMetadata`).

I've also removed the return values from the setters since those are not used anywhere.

This PR can probably be targeted to the 6.2 branch too.