### PR TITLE
Support monolog 2.0*

### DIFF
--- a/Profiler/Handler/CollectionHandler.php
+++ b/Profiler/Handler/CollectionHandler.php
@@ -26,7 +26,7 @@ class CollectionHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    protected function write(array $record)
+    protected function write(array $record) :void
     {
         $this->records[] = $record;
     }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "doctrine/cache": "^1.7",
         "doctrine/inflector": "^1.3",
         "doctrine/collections": "^1.5",
-        "monolog/monolog": "^1.24",
+        "monolog/monolog": "^1.24|^2.0",
         "elasticsearch/elasticsearch": "^7.0",
         "ongr/elasticsearch-dsl": "^7.0"
     },


### PR DESCRIPTION
This PR opens the possibility to use the bundle with the last version of SF5 that required monolog 2.X

What I did:

- [ ] Change the dependency configuration
- [ ] Update CollectionHandler