### PR TITLE
Fix return type of AbstractResultsIterator::getDocumentScore()

### DIFF
--- a/Result/AbstractResultsIterator.php
+++ b/Result/AbstractResultsIterator.php
@@ -241,7 +241,7 @@ abstract class AbstractResultsIterator implements \Countable, \Iterator
     /**
      * Returns score of current hit.
      */
-    public function getDocumentScore(): int
+    public function getDocumentScore(): ?int
     {
         if (!$this->valid()) {
             throw new \LogicException('Document score is available only while iterating over results.');


### PR DESCRIPTION
It returns `null` when there is no score.