### PR TITLE
Instantiate document classes without calling their constructor when denormalizing

### DIFF
--- a/Mapping/Converter.php
+++ b/Mapping/Converter.php
@@ -11,6 +11,7 @@
 
 namespace ONGR\ElasticsearchBundle\Mapping;
 
+use Doctrine\Instantiator\Instantiator;
 use ONGR\ElasticsearchBundle\Result\ObjectIterator;
 
 /**
@@ -18,6 +19,11 @@ use ONGR\ElasticsearchBundle\Result\ObjectIterator;
  */
 class Converter
 {
+    /**
+     * @var Instantiator
+     */
+    private $instantiator;
+
     private $propertyMetadata = [];
 
     public function addClassMetadata(string $class, array $metadata): void
@@ -75,8 +81,12 @@ class Converter
 
     protected function denormalize(array $raw, string $namespace)
     {
+        if ($this->instantiator === null) {
+            $this->instantiator = new Instantiator();
+        }
+
         $metadata = $this->propertyMetadata[$namespace];
-        $object = new $namespace();
+        $object = $this->instantiator->instantiate($namespace);
 
         foreach ($raw as $field => $value) {
             $fieldMeta = $metadata[$field];

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "doctrine/annotations": "^1.6",
         "doctrine/cache": "^1.7",
         "doctrine/inflector": "^1.3",
+        "doctrine/instantiator": "^1.1",
         "doctrine/collections": "^1.5",
         "monolog/monolog": "^1.24",
         "elasticsearch/elasticsearch": "^6.0",


### PR DESCRIPTION
Denormalization restores a document class from its state, which means that the constructor should not be called because no new object is created there.

This also allows the document class's constructor to be parametrized because it doesn't get called in this library anymore.