### PR TITLE
Allow to change the default hosts for all indexes

### DIFF
--- a/Annotation/Index.php
+++ b/Annotation/Index.php
@@ -26,12 +26,7 @@ final class Index extends AbstractAnnotation
      */
     public $alias;
 
-    /**
-     * Index alias name. By default the index name will be created with the timestamp appended to the alias.
-     */
-    public $hosts = [
-        '127.0.0.1:9200'
-    ];
+    public $hosts;
 
     public $numberOfShards = 5;
 

--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -58,6 +58,7 @@ class MappingPass implements CompilerPassInterface
     {
         /** @var DocumentParser $parser */
         $parser = $container->get(DocumentParser::class);
+        $defaultHosts = $container->getParameter(Configuration::ONGR_DEFAULT_HOSTS);
         $indexesOverride = $container->getParameter(Configuration::ONGR_INDEXES_OVERRIDE);
         $converterDefinition = $container->getDefinition(Converter::class);
 
@@ -100,7 +101,7 @@ class MappingPass implements CompilerPassInterface
                         $indexAlias,
                         $indexAlias,
                         $indexMetadata,
-                        $indexesOverride[$namespace]['hosts'] ?? $document->hosts,
+                        $indexesOverride[$namespace]['hosts'] ?? $document->hosts ?? $defaultHosts,
                         $indexesOverride[$namespace]['default'] ?? $document->default,
                         $indexesOverride[$namespace]['type'] ?? $document->typeName
                     ]

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,7 @@ class Configuration implements ConfigurationInterface
     const ONGR_PROFILER_CONFIG = 'ongr.esb.profiler';
     const ONGR_LOGGER_CONFIG = 'ongr.esb.logger';
     const ONGR_ANALYSIS_CONFIG = 'ongr.esb.analysis';
+    const ONGR_DEFAULT_HOSTS = 'ongr.esb.default_hosts';
     const ONGR_INDEXES = 'ongr.esb.indexes';
     const ONGR_DEFAULT_INDEX = 'ongr.esb.default_index';
     const ONGR_INDEXES_OVERRIDE = 'ongr.esb.indexes_override';
@@ -52,7 +53,7 @@ class Configuration implements ConfigurationInterface
 
             ->booleanNode('profiler')
                 ->info(
-                    'Enables Symfony profiler for the elasticsearch queries debug.'.
+                    'Enables Symfony profiler for the elasticsearch queries debug. '.
                     'Default value is kernel.debug parameter. '
                 )
             ->end()
@@ -61,6 +62,15 @@ class Configuration implements ConfigurationInterface
                 ->defaultTrue()
                 ->info(
                     'Enables executed queries logging. Log file names are the same as index.'
+                )
+            ->end()
+
+            ->arrayNode('hosts')
+                ->prototype('scalar')->end()
+                ->defaultValue(['127.0.0.1:9200'])
+                ->info(
+                    'Allows to define default hosts for indexes, when not explicitly set in the index. ' .
+                    'Default is `127.0.0.1:9200`.'
                 )
             ->end()
 

--- a/DependencyInjection/ONGRElasticsearchExtension.php
+++ b/DependencyInjection/ONGRElasticsearchExtension.php
@@ -43,6 +43,7 @@ class ONGRElasticsearchExtension extends Extension
             $config['logger'] ?? $container->getParameter('kernel.debug')
         );
 
+        $container->setParameter(Configuration::ONGR_DEFAULT_HOSTS, $config['hosts']);
         $container->setParameter(Configuration::ONGR_INDEXES_OVERRIDE, $config['indexes']);
         $container->setParameter(Configuration::ONGR_ANALYSIS_CONFIG, $config['analysis']);
         $container->setParameter(Configuration::ONGR_SOURCE_DIR, $config['source_directories']);

--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -25,6 +25,8 @@ ongr_elasticsearch:
     logger: false 
     profiler: true
     cache: true
+    hosts:
+        - 'elasticsearch:9200'
     indexes: # overrides any index related config from anotations
         App\Document\Page:
             default: true


### PR DESCRIPTION
When the ES host is other than localhost (or default port) it's very cumbersome to manually define the (same) host for every single index.

Thus, I implemented a possibility to define the default hosts for all indexes in YAML. They can be overridden per index via YAML or annotations, of course.