### PR TITLE
Fix es7 total hits

### DIFF
--- a/Result/AbstractResultsIterator.php
+++ b/Result/AbstractResultsIterator.php
@@ -102,7 +102,11 @@ abstract class AbstractResultsIterator implements \Countable, \Iterator
             $this->documents = $rawData['hits']['hits'];
         }
         if (isset($rawData['hits']['total'])) {
-            $this->count = $rawData['hits']['total'];
+            if (isset($rawData['hits']['total']['value'])) {
+                $this->count = $rawData['hits']['total']['value'];
+            } else {
+                $this->count = $rawData['hits']['total'];
+            }
         }
     }
 


### PR DESCRIPTION
Since https://github.com/ongr-io/ElasticsearchBundle/pull/909 the 5.2 version support ES 7 but there is false response of the count as the api will return total as object.