### PR TITLE
Deprecate IndexService::clearElasticIndexCache()

### DIFF
--- a/Service/IndexService.php
+++ b/Service/IndexService.php
@@ -522,6 +522,9 @@ class IndexService
         $this->client = null;
     }
 
+    /**
+     * @deprecated use `clearCache()` instead
+     */
     public function clearElasticIndexCache(): array
     {
         return $this->getClient()->indices()->clearCache(['index' => $this->getIndexName()]);


### PR DESCRIPTION
It's a duplicate of `IndexService::clearCache()`.