### PR TITLE
Added trim in getFullNamespace($filename)

### DIFF
--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -165,7 +165,7 @@ class MappingPass implements CompilerPassInterface
         $lines = preg_grep('/^namespace /', file($filename));
         $namespaceLine = array_shift($lines);
         $match = array();
-        preg_match('/^namespace (.*);$/', $namespaceLine, $match);
+        preg_match('/^namespace (.*);$/', trim($namespaceLine), $match);
         $fullNamespace = array_pop($match);
 
         return $fullNamespace;


### PR DESCRIPTION
Did not trim /r/n at the end of the line `$namespaceLine` in `preg_match('/^namespace (.*);$/', $namespaceLine, $match)`