### PR TITLE
Fixed issue with windows directory separator

### DIFF
--- a/DependencyInjection/Compiler/MappingPass.php
+++ b/DependencyInjection/Compiler/MappingPass.php
@@ -173,7 +173,7 @@ class MappingPass implements CompilerPassInterface
 
     private function getClassname($filename)
     {
-        $directoriesAndFilename = explode('/', $filename);
+        $directoriesAndFilename = explode(DIRECTORY_SEPARATOR, $filename);
         $filename = array_pop($directoriesAndFilename);
         $nameAndExtension = explode('.', $filename);
         $className = array_shift($nameAndExtension);


### PR DESCRIPTION
Without this fix I got on my fresh SF5 project on WIndows following issue
```
In MappingPass.php line 65:
  Class App\Document\src\Document\LogEntry does not exist  
```