### PR TITLE
change default source directory to /src/Document

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -66,9 +66,9 @@ class Configuration implements ConfigurationInterface
 
             ->arrayNode('source_directories')
                 ->prototype('scalar')->end()
-                ->defaultValue(['/src'])
+                ->defaultValue(['/src/Document'])
                 ->info(
-                    'If your project has different than `/src` source directory, or several of them,' .
+                    'If your documents are stored in a different folder than `/src/Document`, or several of them,' .
                     'you can specify them here to look automatically for ES documents.'
                 )
             ->end()

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ return [
 Add minimal configuration for Elasticsearch bundle.
 
 ```yaml
-
 # config/packages/ongr_elasticsearch.yaml
 ongr_elasticsearch:
+    source_directories: [/src/Document]
     analysis:
         filter:
             edge_ngram_filter: #-> your custom filter name to use in the analyzer below
@@ -110,7 +110,6 @@ ongr_elasticsearch:
     indexes:
         App\Document\Product:
             hosts: [elasticsearch:9200] # optional, the default is 127.0.0.1:9200
-
 ```
 
 > This is the very basic example only, for more information, please take a look at the [configuration][9] chapter.


### PR DESCRIPTION
It cannot be assumed all classes in /src abide by the PSR-0 standard or have autoloading setup in a different way. For instance, Doctrine Migrations after default SF5 setup, will be placed in /src/Migrations and they cannot be autoloaded by default.

Since the README.md suggests to place new Document classes in /src/Document, it is my proposal to make "/src/Document" the default source directory for the ElasticsearchBundle so developers can install this bundle on new Symfony 5 application without running into autoloading issues.